### PR TITLE
feat(crypto): implement encryption primitives, key hierarchy, and item encryption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - `rustfmt.toml` and `clippy.toml` with project-wide conventions (edition 2024, `unsafe` denied, pedantic warnings)
 - Apple Developer enrollment guide (`docs/apple-developer-setup.md`)
 - ADR-006: Tech stack consolidation — Rust for crypto, CLI, and server; Swift for iOS; TypeScript for web; Python for ETL
+- Core cryptographic primitives: Argon2id key derivation, HKDF-SHA-256, AES-256-GCM encrypt/decrypt, AES-256-GCM key wrapping, X25519 key exchange, BLAKE2b hashing
+- Full key hierarchy: master key derivation from password, sub-key derivation (auth key + master encryption key), vault key and item key generation, wrapping, and unwrapping
+- Vault re-keying to re-wrap all item keys under a new vault key
+- Recovery key generation with human-readable Crockford Base32 encoding and checksum
+- Item-level encryption with per-item random keys wrapped by the vault key
+- Encrypted blob format (v1) with version byte for future migration support
+- Blob size padding to fixed buckets (512 B, 2 KiB, 8 KiB, 32 KiB) to prevent size-based inference
+- Generic typed encryption helpers (`encrypt_json`/`decrypt_json`) for any serializable domain object
+- AAD domain separation tags for all key wrapping and item encryption operations
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,16 +3,87 @@
 version = 4
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures",
+ "password-hash",
+]
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "blake2"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46502ad458c9a52b69d4d4d32775c788b7a1b85e8bc9d482d92250fc0e3f8efe"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
 
 [[package]]
 name = "bumpalo"
@@ -27,16 +98,119 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "typenum",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
 
 [[package]]
 name = "getrandom"
@@ -49,6 +223,16 @@ dependencies = [
  "r-efi",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -73,6 +257,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex-literal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -88,6 +302,15 @@ dependencies = [
  "hashbrown 0.17.0",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -137,6 +360,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "pildora-cli"
 version = "0.1.0"
 dependencies = [
@@ -147,10 +387,19 @@ dependencies = [
 name = "pildora-crypto"
 version = "0.1.0"
 dependencies = [
+ "aes-gcm",
+ "argon2",
+ "blake2",
+ "hex",
+ "hex-literal",
+ "hkdf",
+ "rand",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror",
  "uuid",
+ "x25519-dalek",
  "zeroize",
 ]
 
@@ -159,6 +408,27 @@ name = "pildora-server"
 version = "0.1.0"
 dependencies = [
  "pildora-crypto",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
 ]
 
 [[package]]
@@ -194,6 +464,45 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
 
 [[package]]
 name = "rustversion"
@@ -251,6 +560,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -282,6 +608,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -294,16 +626,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
+
+[[package]]
 name = "uuid"
 version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
- "getrandom",
+ "getrandom 0.4.2",
  "js-sys",
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
@@ -494,6 +848,38 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "x25519-dalek"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7e468321c81fb07fa7f4c636c3972b9100f0346e5b6a9f2bd0603a52f7ed277"
+dependencies = [
+ "curve25519-dalek",
+ "rand_core",
+ "serde",
+ "zeroize",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/crypto/Cargo.toml
+++ b/crypto/Cargo.toml
@@ -11,10 +11,19 @@ publish = false
 workspace = true
 
 [dependencies]
+aes-gcm = "0.10"
+argon2 = "0.5"
+blake2 = "0.10"
+hkdf = "0.12"
+rand = "0.8"
 serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+sha2 = "0.10"
 thiserror = "2"
 uuid = { version = "1", features = ["v4", "serde"] }
+x25519-dalek = { version = "2", features = ["static_secrets"] }
 zeroize = { version = "1", features = ["derive"] }
 
 [dev-dependencies]
-serde_json = "1"
+hex = "0.4"
+hex-literal = "0.4"

--- a/crypto/src/key_hierarchy.rs
+++ b/crypto/src/key_hierarchy.rs
@@ -1,0 +1,555 @@
+//! Key hierarchy: master key derivation, sub-key derivation, and key
+//! wrapping/unwrapping for vault and item keys.
+//!
+//! Implements the full key hierarchy from ADR-001:
+//!
+//! ```text
+//! Master Password
+//!     → [Argon2id + salt] → Master Key (MK)
+//!         → [HKDF] → Authentication Key (for SRP)
+//!         → [HKDF] → Master Encryption Key (MEK)
+//!             → wraps → Vault Key (VK)  [AES-256-GCM keywrap]
+//!                 → wraps → Item Key (IK) [AES-256-GCM keywrap]
+//! ```
+
+use zeroize::{Zeroize, ZeroizeOnDrop};
+
+use crate::error::Result;
+use crate::primitives::{self, KEY_LEN, WRAPPED_KEY_LEN};
+
+// ── Domain separation AAD tags ───────────────────────────────────────────────
+
+const AAD_VAULT_KEY: &[u8] = b"pildora:v1:wrapped-vault-key";
+const AAD_ITEM_KEY: &[u8] = b"pildora:v1:wrapped-item-key";
+const AAD_RECOVERY_MEK: &[u8] = b"pildora:v1:recovery-wrapped-mek";
+
+// HKDF info strings for sub-key derivation
+const HKDF_INFO_AUTH: &[u8] = b"pildora:v1:auth-key";
+const HKDF_INFO_MEK: &[u8] = b"pildora:v1:master-encryption-key";
+
+// ── Key types ────────────────────────────────────────────────────────────────
+
+/// Master Key — derived from the user's password via Argon2id.
+/// Never stored; re-derived on unlock.
+#[derive(Clone, Zeroize, ZeroizeOnDrop)]
+pub struct MasterKey([u8; KEY_LEN]);
+
+impl MasterKey {
+    #[must_use]
+    pub fn from_bytes(bytes: [u8; KEY_LEN]) -> Self {
+        Self(bytes)
+    }
+
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8; KEY_LEN] {
+        &self.0
+    }
+}
+
+impl std::fmt::Debug for MasterKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("MasterKey([REDACTED])")
+    }
+}
+
+/// Authentication Key — derived from MK via HKDF. Used for SRP-6a.
+#[derive(Clone, Zeroize, ZeroizeOnDrop)]
+pub struct AuthKey([u8; KEY_LEN]);
+
+impl AuthKey {
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8; KEY_LEN] {
+        &self.0
+    }
+}
+
+impl std::fmt::Debug for AuthKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("AuthKey([REDACTED])")
+    }
+}
+
+/// Master Encryption Key — derived from MK via HKDF. Wraps vault keys.
+#[derive(Clone, Zeroize, ZeroizeOnDrop)]
+pub struct MasterEncryptionKey([u8; KEY_LEN]);
+
+impl MasterEncryptionKey {
+    #[must_use]
+    pub fn from_bytes(bytes: [u8; KEY_LEN]) -> Self {
+        Self(bytes)
+    }
+
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8; KEY_LEN] {
+        &self.0
+    }
+}
+
+impl std::fmt::Debug for MasterEncryptionKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("MasterEncryptionKey([REDACTED])")
+    }
+}
+
+/// Vault Key — random 256-bit key that encrypts items within a vault.
+#[derive(Clone, Zeroize, ZeroizeOnDrop)]
+pub struct VaultKey([u8; KEY_LEN]);
+
+impl VaultKey {
+    #[must_use]
+    pub fn from_bytes(bytes: [u8; KEY_LEN]) -> Self {
+        Self(bytes)
+    }
+
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8; KEY_LEN] {
+        &self.0
+    }
+}
+
+impl std::fmt::Debug for VaultKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("VaultKey([REDACTED])")
+    }
+}
+
+/// Item Key — random 256-bit key that encrypts a single vault item.
+#[derive(Clone, Zeroize, ZeroizeOnDrop)]
+pub struct ItemKey([u8; KEY_LEN]);
+
+impl ItemKey {
+    #[must_use]
+    pub fn from_bytes(bytes: [u8; KEY_LEN]) -> Self {
+        Self(bytes)
+    }
+
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8; KEY_LEN] {
+        &self.0
+    }
+}
+
+impl std::fmt::Debug for ItemKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("ItemKey([REDACTED])")
+    }
+}
+
+/// A vault key wrapped (encrypted) by the MEK.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct WrappedVaultKey(pub Vec<u8>);
+
+impl WrappedVaultKey {
+    /// Expected length in bytes.
+    pub const LEN: usize = WRAPPED_KEY_LEN;
+}
+
+/// An item key wrapped (encrypted) by a vault key.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct WrappedItemKey(pub Vec<u8>);
+
+impl WrappedItemKey {
+    /// Expected length in bytes.
+    pub const LEN: usize = WRAPPED_KEY_LEN;
+}
+
+/// A recovery key — random secret that can unwrap the MEK as an alternate
+/// path to account recovery. Encoded as human-readable grouped text.
+#[derive(Clone, Zeroize, ZeroizeOnDrop)]
+pub struct RecoveryKey([u8; KEY_LEN]);
+
+impl RecoveryKey {
+    /// Raw bytes of the recovery key.
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8; KEY_LEN] {
+        &self.0
+    }
+
+    /// Encode as a human-readable string in groups of 5 characters using
+    /// Crockford Base32 (case-insensitive, no ambiguous chars).
+    ///
+    /// Format: `XXXXX-XXXXX-XXXXX-...-CC` where CC is a 2-char checksum.
+    #[must_use]
+    pub fn to_display_string(&self) -> String {
+        // Simple base32 encoding using Crockford alphabet (no I, L, O, U)
+        const ALPHABET: &[u8; 32] = b"0123456789ABCDEFGHJKMNPQRSTVWXYZ";
+
+        // Encode 32 bytes = 256 bits → ceil(256/5) = 52 base32 chars
+        let mut chars = Vec::with_capacity(56);
+        let mut buffer: u64 = 0;
+        let mut bits_in_buffer = 0;
+
+        for &byte in &self.0 {
+            buffer = (buffer << 8) | u64::from(byte);
+            bits_in_buffer += 8;
+            while bits_in_buffer >= 5 {
+                bits_in_buffer -= 5;
+                let idx = ((buffer >> bits_in_buffer) & 0x1F) as usize;
+                chars.push(ALPHABET[idx]);
+            }
+        }
+        if bits_in_buffer > 0 {
+            let idx = ((buffer << (5 - bits_in_buffer)) & 0x1F) as usize;
+            chars.push(ALPHABET[idx]);
+        }
+
+        // 2-char checksum (first 10 bits of BLAKE2b hash)
+        let hash = primitives::blake2b_hash(&self.0);
+        let check_val = (u16::from(hash[0]) << 2) | (u16::from(hash[1]) >> 6);
+        let c1 = ALPHABET[(check_val >> 5) as usize & 0x1F];
+        let c2 = ALPHABET[(check_val & 0x1F) as usize];
+        chars.push(c1);
+        chars.push(c2);
+
+        // Group in 5s separated by dashes
+        let grouped: Vec<String> = chars
+            .chunks(5)
+            .map(|c| c.iter().map(|&b| b as char).collect())
+            .collect();
+        grouped.join("-")
+    }
+}
+
+impl std::fmt::Debug for RecoveryKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("RecoveryKey([REDACTED])")
+    }
+}
+
+/// MEK wrapped by the recovery key (stored alongside the vault).
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
+pub struct RecoveryWrappedMek(pub Vec<u8>);
+
+// ── Key derivation ───────────────────────────────────────────────────────────
+
+/// Derive the master key from a password and salt using Argon2id.
+pub fn derive_master_key(password: &[u8], salt: &[u8]) -> Result<MasterKey> {
+    let bytes = primitives::derive_key_argon2id(password, salt)?;
+    Ok(MasterKey(bytes))
+}
+
+/// Derive authentication key and master encryption key from the master key.
+pub fn derive_sub_keys(mk: &MasterKey) -> Result<(AuthKey, MasterEncryptionKey)> {
+    let auth_bytes = primitives::hkdf_sha256(mk.as_bytes(), None, HKDF_INFO_AUTH, KEY_LEN)?;
+    let mek_bytes = primitives::hkdf_sha256(mk.as_bytes(), None, HKDF_INFO_MEK, KEY_LEN)?;
+
+    let mut auth_arr = [0u8; KEY_LEN];
+    auth_arr.copy_from_slice(&auth_bytes);
+
+    let mut mek_arr = [0u8; KEY_LEN];
+    mek_arr.copy_from_slice(&mek_bytes);
+
+    Ok((AuthKey(auth_arr), MasterEncryptionKey(mek_arr)))
+}
+
+// ── Vault key operations ─────────────────────────────────────────────────────
+
+/// Generate a random vault key.
+#[must_use]
+pub fn generate_vault_key() -> VaultKey {
+    VaultKey(primitives::generate_random_key())
+}
+
+/// Wrap a vault key with the MEK for storage.
+pub fn wrap_vault_key(vk: &VaultKey, mek: &MasterEncryptionKey) -> Result<WrappedVaultKey> {
+    let wrapped = primitives::aes256_gcm_keywrap(mek.as_bytes(), vk.as_bytes(), AAD_VAULT_KEY)?;
+    Ok(WrappedVaultKey(wrapped))
+}
+
+/// Unwrap a vault key using the MEK.
+pub fn unwrap_vault_key(wrapped: &WrappedVaultKey, mek: &MasterEncryptionKey) -> Result<VaultKey> {
+    let bytes = primitives::aes256_gcm_key_unwrap(mek.as_bytes(), &wrapped.0, AAD_VAULT_KEY)?;
+    Ok(VaultKey(bytes))
+}
+
+// ── Item key operations ──────────────────────────────────────────────────────
+
+/// Generate a random item key.
+#[must_use]
+pub fn generate_item_key() -> ItemKey {
+    ItemKey(primitives::generate_random_key())
+}
+
+/// Wrap an item key with a vault key for storage.
+pub fn wrap_item_key(ik: &ItemKey, vk: &VaultKey) -> Result<WrappedItemKey> {
+    let wrapped = primitives::aes256_gcm_keywrap(vk.as_bytes(), ik.as_bytes(), AAD_ITEM_KEY)?;
+    Ok(WrappedItemKey(wrapped))
+}
+
+/// Unwrap an item key using a vault key.
+pub fn unwrap_item_key(wrapped: &WrappedItemKey, vk: &VaultKey) -> Result<ItemKey> {
+    let bytes = primitives::aes256_gcm_key_unwrap(vk.as_bytes(), &wrapped.0, AAD_ITEM_KEY)?;
+    Ok(ItemKey(bytes))
+}
+
+// ── Vault rekey ──────────────────────────────────────────────────────────────
+
+/// Re-wrap all item keys from an old vault key to a new one.
+///
+/// This is a **re-wrap** operation: each item key is unwrapped with `old_vk`
+/// and re-wrapped with `new_vk`. Item ciphertext is not touched.
+pub fn vault_rekey(
+    old_vk: &VaultKey,
+    new_vk: &VaultKey,
+    wrapped_item_keys: &[WrappedItemKey],
+) -> Result<Vec<WrappedItemKey>> {
+    wrapped_item_keys
+        .iter()
+        .map(|wik| {
+            let ik = unwrap_item_key(wik, old_vk)?;
+            wrap_item_key(&ik, new_vk)
+        })
+        .collect()
+}
+
+// ── Recovery key ─────────────────────────────────────────────────────────────
+
+/// Generate a random recovery key.
+#[must_use]
+pub fn generate_recovery_key() -> RecoveryKey {
+    RecoveryKey(primitives::generate_random_key())
+}
+
+/// Wrap the MEK with the recovery key for offline backup.
+pub fn wrap_mek_for_recovery(
+    mek: &MasterEncryptionKey,
+    recovery_key: &RecoveryKey,
+) -> Result<RecoveryWrappedMek> {
+    let wrapped =
+        primitives::aes256_gcm_keywrap(recovery_key.as_bytes(), mek.as_bytes(), AAD_RECOVERY_MEK)?;
+    Ok(RecoveryWrappedMek(wrapped))
+}
+
+/// Unwrap the MEK using a recovery key.
+pub fn unwrap_mek_from_recovery(
+    wrapped: &RecoveryWrappedMek,
+    recovery_key: &RecoveryKey,
+) -> Result<MasterEncryptionKey> {
+    let bytes =
+        primitives::aes256_gcm_key_unwrap(recovery_key.as_bytes(), &wrapped.0, AAD_RECOVERY_MEK)?;
+    Ok(MasterEncryptionKey(bytes))
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TEST_PASSWORD: &[u8] = b"correct horse battery staple";
+    const TEST_SALT: &[u8] = b"saltsaltsaltsalt"; // 16 bytes
+
+    // ── Master key derivation ────────────────────────────────────────────
+
+    #[test]
+    fn derive_master_key_deterministic() {
+        let mk1 = derive_master_key(TEST_PASSWORD, TEST_SALT).unwrap();
+        let mk2 = derive_master_key(TEST_PASSWORD, TEST_SALT).unwrap();
+        assert_eq!(mk1.as_bytes(), mk2.as_bytes());
+    }
+
+    #[test]
+    fn derive_master_key_different_passwords() {
+        let mk1 = derive_master_key(b"password1", TEST_SALT).unwrap();
+        let mk2 = derive_master_key(b"password2", TEST_SALT).unwrap();
+        assert_ne!(mk1.as_bytes(), mk2.as_bytes());
+    }
+
+    // ── Sub-key derivation ───────────────────────────────────────────────
+
+    #[test]
+    fn derive_sub_keys_produces_different_keys() {
+        let mk = derive_master_key(TEST_PASSWORD, TEST_SALT).unwrap();
+        let (auth, mek) = derive_sub_keys(&mk).unwrap();
+        assert_ne!(auth.as_bytes(), mek.as_bytes());
+    }
+
+    #[test]
+    fn derive_sub_keys_deterministic() {
+        let mk = derive_master_key(TEST_PASSWORD, TEST_SALT).unwrap();
+        let (auth1, mek1) = derive_sub_keys(&mk).unwrap();
+        let (auth2, mek2) = derive_sub_keys(&mk).unwrap();
+        assert_eq!(auth1.as_bytes(), auth2.as_bytes());
+        assert_eq!(mek1.as_bytes(), mek2.as_bytes());
+    }
+
+    // ── Full key hierarchy roundtrip ─────────────────────────────────────
+
+    #[test]
+    fn full_hierarchy_roundtrip() {
+        // password → MK → MEK → wrap VK → unwrap VK → wrap IK → unwrap IK
+        let mk = derive_master_key(TEST_PASSWORD, TEST_SALT).unwrap();
+        let (_auth, mek) = derive_sub_keys(&mk).unwrap();
+
+        let vk = generate_vault_key();
+        let wrapped_vk = wrap_vault_key(&vk, &mek).unwrap();
+        let unwrapped_vk = unwrap_vault_key(&wrapped_vk, &mek).unwrap();
+        assert_eq!(vk.as_bytes(), unwrapped_vk.as_bytes());
+
+        let ik = generate_item_key();
+        let wrapped_ik = wrap_item_key(&ik, &unwrapped_vk).unwrap();
+        let unwrapped_ik = unwrap_item_key(&wrapped_ik, &unwrapped_vk).unwrap();
+        assert_eq!(ik.as_bytes(), unwrapped_ik.as_bytes());
+    }
+
+    // ── Wrong password fails to unwrap ───────────────────────────────────
+
+    #[test]
+    fn wrong_password_fails_to_unwrap_vault_key() {
+        let mk_correct = derive_master_key(b"correct", TEST_SALT).unwrap();
+        let (_, mek_correct) = derive_sub_keys(&mk_correct).unwrap();
+
+        let vk = generate_vault_key();
+        let wrapped_vk = wrap_vault_key(&vk, &mek_correct).unwrap();
+
+        let mk_wrong = derive_master_key(b"wrong", TEST_SALT).unwrap();
+        let (_, mek_wrong) = derive_sub_keys(&mk_wrong).unwrap();
+
+        assert!(unwrap_vault_key(&wrapped_vk, &mek_wrong).is_err());
+    }
+
+    // ── Vault rekey ──────────────────────────────────────────────────────
+
+    #[test]
+    fn vault_rekey_rewraps_all_items() {
+        let old_vk = generate_vault_key();
+        let new_vk = generate_vault_key();
+
+        // Create some item keys and wrap them with old VK
+        let item_keys: Vec<ItemKey> = (0..5).map(|_| generate_item_key()).collect();
+        let wrapped: Vec<WrappedItemKey> = item_keys
+            .iter()
+            .map(|ik| wrap_item_key(ik, &old_vk).unwrap())
+            .collect();
+
+        // Rekey
+        let re_wrapped = vault_rekey(&old_vk, &new_vk, &wrapped).unwrap();
+        assert_eq!(re_wrapped.len(), 5);
+
+        // All items unwrappable with new VK
+        for (i, wik) in re_wrapped.iter().enumerate() {
+            let unwrapped = unwrap_item_key(wik, &new_vk).unwrap();
+            assert_eq!(unwrapped.as_bytes(), item_keys[i].as_bytes());
+        }
+
+        // Old VK cannot unwrap re-wrapped keys
+        for wik in &re_wrapped {
+            assert!(unwrap_item_key(wik, &old_vk).is_err());
+        }
+    }
+
+    #[test]
+    fn vault_rekey_empty_list() {
+        let old_vk = generate_vault_key();
+        let new_vk = generate_vault_key();
+        let result = vault_rekey(&old_vk, &new_vk, &[]).unwrap();
+        assert!(result.is_empty());
+    }
+
+    // ── Recovery key ─────────────────────────────────────────────────────
+
+    #[test]
+    fn recovery_key_roundtrip() {
+        let mk = derive_master_key(TEST_PASSWORD, TEST_SALT).unwrap();
+        let (_, mek) = derive_sub_keys(&mk).unwrap();
+
+        let rk = generate_recovery_key();
+        let wrapped = wrap_mek_for_recovery(&mek, &rk).unwrap();
+        let recovered_mek = unwrap_mek_from_recovery(&wrapped, &rk).unwrap();
+
+        assert_eq!(mek.as_bytes(), recovered_mek.as_bytes());
+    }
+
+    #[test]
+    fn recovery_key_wrong_key_fails() {
+        let mk = derive_master_key(TEST_PASSWORD, TEST_SALT).unwrap();
+        let (_, mek) = derive_sub_keys(&mk).unwrap();
+
+        let rk = generate_recovery_key();
+        let wrong_rk = generate_recovery_key();
+        let wrapped = wrap_mek_for_recovery(&mek, &rk).unwrap();
+
+        assert!(unwrap_mek_from_recovery(&wrapped, &wrong_rk).is_err());
+    }
+
+    #[test]
+    fn recovery_key_can_unwrap_vault_keys() {
+        // Full flow: recovery key → MEK → unwrap VK → unwrap IK
+        let mk = derive_master_key(TEST_PASSWORD, TEST_SALT).unwrap();
+        let (_, mek) = derive_sub_keys(&mk).unwrap();
+
+        let vk = generate_vault_key();
+        let wrapped_vk = wrap_vault_key(&vk, &mek).unwrap();
+
+        let ik = generate_item_key();
+        let wrapped_ik = wrap_item_key(&ik, &vk).unwrap();
+
+        // Simulate recovery
+        let rk = generate_recovery_key();
+        let recovery_blob = wrap_mek_for_recovery(&mek, &rk).unwrap();
+
+        let recovered_mek = unwrap_mek_from_recovery(&recovery_blob, &rk).unwrap();
+        let recovered_vk = unwrap_vault_key(&wrapped_vk, &recovered_mek).unwrap();
+        let recovered_ik = unwrap_item_key(&wrapped_ik, &recovered_vk).unwrap();
+
+        assert_eq!(ik.as_bytes(), recovered_ik.as_bytes());
+    }
+
+    #[test]
+    fn recovery_key_display_format() {
+        let rk = generate_recovery_key();
+        let display = rk.to_display_string();
+        // Should be groups of 5 separated by dashes, with checksum
+        assert!(display.contains('-'));
+        for group in display.split('-') {
+            assert!(group.len() <= 5);
+            assert!(group.chars().all(|c| c.is_ascii_alphanumeric()));
+        }
+    }
+
+    #[test]
+    fn recovery_key_display_deterministic() {
+        let bytes = [0x42u8; KEY_LEN];
+        let rk = RecoveryKey(bytes);
+        let d1 = rk.to_display_string();
+        let rk2 = RecoveryKey(bytes);
+        let d2 = rk2.to_display_string();
+        assert_eq!(d1, d2);
+    }
+
+    // ── Debug redaction ──────────────────────────────────────────────────
+
+    #[test]
+    fn all_key_types_redacted() {
+        let mk = MasterKey::from_bytes([0; KEY_LEN]);
+        let ak = AuthKey([0; KEY_LEN]);
+        let mek = MasterEncryptionKey::from_bytes([0; KEY_LEN]);
+        let vk = VaultKey::from_bytes([0; KEY_LEN]);
+        let ik = ItemKey::from_bytes([0; KEY_LEN]);
+        let rk = RecoveryKey([0; KEY_LEN]);
+
+        assert!(format!("{mk:?}").contains("REDACTED"));
+        assert!(format!("{ak:?}").contains("REDACTED"));
+        assert!(format!("{mek:?}").contains("REDACTED"));
+        assert!(format!("{vk:?}").contains("REDACTED"));
+        assert!(format!("{ik:?}").contains("REDACTED"));
+        assert!(format!("{rk:?}").contains("REDACTED"));
+    }
+
+    // ── Domain separation ────────────────────────────────────────────────
+
+    #[test]
+    fn vault_key_and_item_key_wrapping_not_interchangeable() {
+        // A vault key wrapped with MEK should not be unwrappable as an item key
+        // (and vice versa) due to AAD domain separation.
+        let mek = MasterEncryptionKey::from_bytes(primitives::generate_random_key());
+        let vk = generate_vault_key();
+
+        let wrapped_vk = wrap_vault_key(&vk, &mek).unwrap();
+
+        // Try to unwrap it as if it were an item key (using mek as vk)
+        let fake_vk = VaultKey::from_bytes(*mek.as_bytes());
+        let fake_wik = WrappedItemKey(wrapped_vk.0.clone());
+        assert!(unwrap_item_key(&fake_wik, &fake_vk).is_err());
+    }
+}

--- a/crypto/src/lib.rs
+++ b/crypto/src/lib.rs
@@ -40,7 +40,9 @@
 //!   use safe Rust via the `RustCrypto` ecosystem.
 
 pub mod error;
+pub mod key_hierarchy;
 pub mod keys;
+pub mod primitives;
 pub mod vault;
 
 /// Encrypted blob version. Embedded as the first byte of every encrypted blob

--- a/crypto/src/primitives.rs
+++ b/crypto/src/primitives.rs
@@ -1,0 +1,577 @@
+//! Low-level cryptographic primitives for pildora-crypto.
+//!
+//! This module wraps the `RustCrypto` ecosystem into ergonomic helpers that the
+//! higher-level key-hierarchy and item-encryption layers build on.  Every
+//! function maps to exactly one algorithm; composition lives in
+//! [`crate::key_hierarchy`] and [`crate::vault`].
+
+use aes_gcm::aead::Aead;
+use aes_gcm::{Aes256Gcm, KeyInit, Nonce};
+use blake2::digest::consts::U32;
+use blake2::{Blake2b, Blake2bMac, Digest};
+use hkdf::Hkdf;
+use rand::RngCore;
+use sha2::Sha256;
+use zeroize::Zeroize;
+
+use crate::error::{CryptoError, Result};
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+/// AES-256-GCM nonce length in bytes (96 bits).
+pub const NONCE_LEN: usize = 12;
+/// AES-256-GCM authentication tag length in bytes (128 bits).
+pub const TAG_LEN: usize = 16;
+/// Symmetric key length in bytes (256 bits).
+pub const KEY_LEN: usize = 32;
+/// Wrapped key overhead: nonce + tag.
+pub const WRAPPED_KEY_OVERHEAD: usize = NONCE_LEN + TAG_LEN;
+/// Total wrapped key blob size: nonce (12) + encrypted key (32) + tag (16).
+pub const WRAPPED_KEY_LEN: usize = KEY_LEN + WRAPPED_KEY_OVERHEAD;
+
+// ── Argon2id ─────────────────────────────────────────────────────────────────
+
+/// Derive a 256-bit key from a password and salt using Argon2id.
+///
+/// Parameters (ADR-001): 64 MiB memory, 3 iterations, parallelism 1.
+pub fn derive_key_argon2id(password: &[u8], salt: &[u8]) -> Result<[u8; KEY_LEN]> {
+    use argon2::{Algorithm, Argon2, Params, Version};
+
+    let params = Params::new(64 * 1024, 3, 1, Some(KEY_LEN))
+        .map_err(|e| CryptoError::KeyDerivation(e.to_string()))?;
+    let argon2 = Argon2::new(Algorithm::Argon2id, Version::V0x13, params);
+
+    let mut output = [0u8; KEY_LEN];
+    argon2
+        .hash_password_into(password, salt, &mut output)
+        .map_err(|e| CryptoError::KeyDerivation(e.to_string()))?;
+    Ok(output)
+}
+
+// ── HKDF-SHA-256 ─────────────────────────────────────────────────────────────
+
+/// HKDF extract-then-expand using SHA-256.
+///
+/// Returns `output_len` bytes of derived key material.
+pub fn hkdf_sha256(
+    ikm: &[u8],
+    salt: Option<&[u8]>,
+    info: &[u8],
+    output_len: usize,
+) -> Result<Vec<u8>> {
+    let hk = Hkdf::<Sha256>::new(salt, ikm);
+    let mut okm = vec![0u8; output_len];
+    hk.expand(info, &mut okm)
+        .map_err(|e| CryptoError::KeyDerivation(e.to_string()))?;
+    Ok(okm)
+}
+
+// ── AES-256-GCM ──────────────────────────────────────────────────────────────
+
+/// Encrypt `plaintext` with AES-256-GCM using a random nonce.
+///
+/// Returns `nonce (12) || ciphertext || tag (16)`.
+/// `aad` is authenticated but not encrypted (associated data).
+pub fn aes256_gcm_encrypt(key: &[u8; KEY_LEN], plaintext: &[u8], aad: &[u8]) -> Result<Vec<u8>> {
+    let cipher =
+        Aes256Gcm::new_from_slice(key).map_err(|e| CryptoError::Encryption(e.to_string()))?;
+
+    let mut nonce_bytes = [0u8; NONCE_LEN];
+    rand::rngs::OsRng.fill_bytes(&mut nonce_bytes);
+    let nonce = Nonce::from_slice(&nonce_bytes);
+
+    let payload = aes_gcm::aead::Payload {
+        msg: plaintext,
+        aad,
+    };
+    let ciphertext = cipher
+        .encrypt(nonce, payload)
+        .map_err(|e| CryptoError::Encryption(e.to_string()))?;
+
+    let mut out = Vec::with_capacity(NONCE_LEN + ciphertext.len());
+    out.extend_from_slice(&nonce_bytes);
+    out.extend_from_slice(&ciphertext);
+    Ok(out)
+}
+
+/// Decrypt a blob produced by [`aes256_gcm_encrypt`].
+///
+/// Expects `nonce (12) || ciphertext || tag (16)`.
+pub fn aes256_gcm_decrypt(
+    key: &[u8; KEY_LEN],
+    ciphertext_with_nonce: &[u8],
+    aad: &[u8],
+) -> Result<Vec<u8>> {
+    if ciphertext_with_nonce.len() < NONCE_LEN + TAG_LEN {
+        return Err(CryptoError::Decryption("input too short".into()));
+    }
+
+    let (nonce_bytes, ct) = ciphertext_with_nonce.split_at(NONCE_LEN);
+    let nonce = Nonce::from_slice(nonce_bytes);
+
+    let cipher =
+        Aes256Gcm::new_from_slice(key).map_err(|e| CryptoError::Decryption(e.to_string()))?;
+
+    let payload = aes_gcm::aead::Payload { msg: ct, aad };
+    cipher
+        .decrypt(nonce, payload)
+        .map_err(|e| CryptoError::Decryption(e.to_string()))
+}
+
+// ── Key wrapping (AES-256-GCM based) ────────────────────────────────────────
+
+/// Wrap a 32-byte key with AES-256-GCM.
+///
+/// `aad` provides domain separation (e.g. `b"pildora:v1:vault-key"`).
+/// Returns a 60-byte blob: `nonce (12) || encrypted_key (32) || tag (16)`.
+pub fn aes256_gcm_keywrap(
+    wrapping_key: &[u8; KEY_LEN],
+    key_to_wrap: &[u8; KEY_LEN],
+    aad: &[u8],
+) -> Result<Vec<u8>> {
+    let result = aes256_gcm_encrypt(wrapping_key, key_to_wrap, aad)?;
+    debug_assert_eq!(result.len(), WRAPPED_KEY_LEN);
+    Ok(result)
+}
+
+/// Unwrap a key previously wrapped by [`aes256_gcm_keywrap`].
+pub fn aes256_gcm_key_unwrap(
+    wrapping_key: &[u8; KEY_LEN],
+    wrapped_key: &[u8],
+    aad: &[u8],
+) -> Result<[u8; KEY_LEN]> {
+    if wrapped_key.len() != WRAPPED_KEY_LEN {
+        return Err(CryptoError::KeyWrap(format!(
+            "expected {} bytes, got {}",
+            WRAPPED_KEY_LEN,
+            wrapped_key.len()
+        )));
+    }
+
+    let mut plaintext = aes256_gcm_decrypt(wrapping_key, wrapped_key, aad)
+        .map_err(|_| CryptoError::KeyWrap("unwrap failed — wrong key or tampered data".into()))?;
+
+    if plaintext.len() != KEY_LEN {
+        plaintext.zeroize();
+        return Err(CryptoError::KeyWrap(
+            "unexpected unwrapped key length".into(),
+        ));
+    }
+
+    let mut key = [0u8; KEY_LEN];
+    key.copy_from_slice(&plaintext);
+    plaintext.zeroize();
+    Ok(key)
+}
+
+// ── X25519 ───────────────────────────────────────────────────────────────────
+
+/// An X25519 static secret key. Zeroized on drop.
+#[derive(Zeroize)]
+#[zeroize(drop)]
+pub struct X25519SecretKey(x25519_dalek::StaticSecret);
+
+impl X25519SecretKey {
+    /// Return the corresponding public key.
+    #[must_use]
+    pub fn public_key(&self) -> X25519PublicKey {
+        X25519PublicKey(x25519_dalek::PublicKey::from(&self.0))
+    }
+}
+
+impl std::fmt::Debug for X25519SecretKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("X25519SecretKey([REDACTED])")
+    }
+}
+
+/// An X25519 public key.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct X25519PublicKey(x25519_dalek::PublicKey);
+
+impl X25519PublicKey {
+    /// Create from raw 32-byte representation.
+    #[must_use]
+    pub fn from_bytes(bytes: [u8; 32]) -> Self {
+        Self(x25519_dalek::PublicKey::from(bytes))
+    }
+
+    /// Raw 32-byte representation.
+    #[must_use]
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        self.0.as_bytes()
+    }
+}
+
+/// Generate a random X25519 keypair.
+#[must_use]
+pub fn x25519_keypair() -> (X25519SecretKey, X25519PublicKey) {
+    let secret = x25519_dalek::StaticSecret::random_from_rng(rand::rngs::OsRng);
+    let public = x25519_dalek::PublicKey::from(&secret);
+    (X25519SecretKey(secret), X25519PublicKey(public))
+}
+
+/// Perform X25519 Diffie-Hellman key agreement.
+///
+/// Returns the 32-byte shared secret.
+pub fn x25519_diffie_hellman(secret: &X25519SecretKey, their_public: &X25519PublicKey) -> [u8; 32] {
+    secret.0.diffie_hellman(&their_public.0).to_bytes()
+}
+
+// ── BLAKE2b ──────────────────────────────────────────────────────────────────
+
+/// Hash `data` with BLAKE2b-256 (unkeyed).
+#[must_use]
+pub fn blake2b_hash(data: &[u8]) -> [u8; 32] {
+    let mut hasher = Blake2b::<U32>::new();
+    Digest::update(&mut hasher, data);
+    hasher.finalize().into()
+}
+
+/// Keyed BLAKE2b-256 MAC.
+///
+/// Alias: [`blake2b_hash_with_key`].
+pub fn blake2b_mac(key: &[u8], data: &[u8]) -> Result<[u8; 32]> {
+    use blake2::digest::Mac;
+    let mut mac = <Blake2bMac<U32> as KeyInit>::new_from_slice(key)
+        .map_err(|e| CryptoError::Encryption(format!("BLAKE2b key error: {e}")))?;
+    Mac::update(&mut mac, data);
+    Ok(mac.finalize().into_bytes().into())
+}
+
+/// Keyed BLAKE2b-256 — convenience alias for [`blake2b_mac`].
+pub fn blake2b_hash_with_key(key: &[u8], data: &[u8]) -> Result<[u8; 32]> {
+    blake2b_mac(key, data)
+}
+
+// ── Random generation ────────────────────────────────────────────────────────
+
+/// Generate a random 16-byte salt for Argon2id.
+#[must_use]
+pub fn generate_salt() -> [u8; 16] {
+    let mut salt = [0u8; 16];
+    rand::rngs::OsRng.fill_bytes(&mut salt);
+    salt
+}
+
+/// Generate a random 32-byte key.
+#[must_use]
+pub fn generate_random_key() -> [u8; KEY_LEN] {
+    let mut key = [0u8; KEY_LEN];
+    rand::rngs::OsRng.fill_bytes(&mut key);
+    key
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use hex_literal::hex;
+
+    // ── Argon2id ─────────────────────────────────────────────────────────
+
+    #[test]
+    fn argon2id_deterministic() {
+        let password = b"password";
+        let salt = b"somesalt12345678"; // 16 bytes
+        let key1 = derive_key_argon2id(password, salt).unwrap();
+        let key2 = derive_key_argon2id(password, salt).unwrap();
+        assert_eq!(key1, key2, "same input must produce same key");
+    }
+
+    #[test]
+    fn argon2id_different_passwords() {
+        let salt = b"somesalt12345678";
+        let k1 = derive_key_argon2id(b"password1", salt).unwrap();
+        let k2 = derive_key_argon2id(b"password2", salt).unwrap();
+        assert_ne!(k1, k2);
+    }
+
+    #[test]
+    fn argon2id_different_salts() {
+        let password = b"password";
+        let k1 = derive_key_argon2id(password, b"salt_one_1234567").unwrap();
+        let k2 = derive_key_argon2id(password, b"salt_two_1234567").unwrap();
+        assert_ne!(k1, k2);
+    }
+
+    #[test]
+    fn argon2id_output_length() {
+        let key = derive_key_argon2id(b"pass", b"saltsaltsaltsalt").unwrap();
+        assert_eq!(key.len(), 32);
+    }
+
+    // ── HKDF-SHA-256 ────────────────────────────────────────────────────
+    //
+    // RFC 5869 Test Case 1
+
+    #[test]
+    fn hkdf_rfc5869_test_case_1() {
+        let ikm = hex!("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b");
+        let salt = hex!("000102030405060708090a0b0c");
+        let info = hex!("f0f1f2f3f4f5f6f7f8f9");
+        let expected = hex!(
+            "3cb25f25faacd57a90434f64d0362f2a"
+            "2d2d0a90cf1a5a4c5db02d56ecc4c5bf"
+            "34007208d5b887185865"
+        );
+
+        let okm = hkdf_sha256(&ikm, Some(&salt), &info, 42).unwrap();
+        assert_eq!(okm, expected);
+    }
+
+    #[test]
+    fn hkdf_different_info_produces_different_keys() {
+        let ikm = [0x42u8; 32];
+        let k1 = hkdf_sha256(&ikm, None, b"auth-key", 32).unwrap();
+        let k2 = hkdf_sha256(&ikm, None, b"encryption-key", 32).unwrap();
+        assert_ne!(k1, k2);
+    }
+
+    // ── AES-256-GCM ─────────────────────────────────────────────────────
+
+    #[test]
+    fn aes_gcm_roundtrip_empty() {
+        let key = generate_random_key();
+        let ct = aes256_gcm_encrypt(&key, b"", b"").unwrap();
+        let pt = aes256_gcm_decrypt(&key, &ct, b"").unwrap();
+        assert!(pt.is_empty());
+    }
+
+    #[test]
+    fn aes_gcm_roundtrip_1_byte() {
+        let key = generate_random_key();
+        let ct = aes256_gcm_encrypt(&key, &[0x42], b"").unwrap();
+        let pt = aes256_gcm_decrypt(&key, &ct, b"").unwrap();
+        assert_eq!(pt, [0x42]);
+    }
+
+    #[test]
+    fn aes_gcm_roundtrip_1kb() {
+        let key = generate_random_key();
+        let data = vec![0xAB; 1024];
+        let ct = aes256_gcm_encrypt(&key, &data, b"").unwrap();
+        let pt = aes256_gcm_decrypt(&key, &ct, b"").unwrap();
+        assert_eq!(pt, data);
+    }
+
+    #[test]
+    fn aes_gcm_roundtrip_1mb() {
+        let key = generate_random_key();
+        let data = vec![0xCD; 1024 * 1024];
+        let ct = aes256_gcm_encrypt(&key, &data, b"").unwrap();
+        let pt = aes256_gcm_decrypt(&key, &ct, b"").unwrap();
+        assert_eq!(pt, data);
+    }
+
+    #[test]
+    fn aes_gcm_with_aad() {
+        let key = generate_random_key();
+        let aad = b"associated data";
+        let ct = aes256_gcm_encrypt(&key, b"hello", aad).unwrap();
+        let pt = aes256_gcm_decrypt(&key, &ct, aad).unwrap();
+        assert_eq!(pt, b"hello");
+    }
+
+    #[test]
+    fn aes_gcm_wrong_aad_fails() {
+        let key = generate_random_key();
+        let ct = aes256_gcm_encrypt(&key, b"hello", b"correct").unwrap();
+        let result = aes256_gcm_decrypt(&key, &ct, b"wrong");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn aes_gcm_wrong_key_fails() {
+        let key1 = generate_random_key();
+        let key2 = generate_random_key();
+        let ct = aes256_gcm_encrypt(&key1, b"hello", b"").unwrap();
+        let result = aes256_gcm_decrypt(&key2, &ct, b"");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn aes_gcm_nondeterministic() {
+        let key = generate_random_key();
+        let ct1 = aes256_gcm_encrypt(&key, b"same", b"").unwrap();
+        let ct2 = aes256_gcm_encrypt(&key, b"same", b"").unwrap();
+        assert_ne!(ct1, ct2, "random nonce must produce different ciphertexts");
+    }
+
+    #[test]
+    fn aes_gcm_tamper_detection() {
+        let key = generate_random_key();
+        let mut ct = aes256_gcm_encrypt(&key, b"hello", b"").unwrap();
+        // Flip a byte in the ciphertext area
+        let idx = NONCE_LEN + 2;
+        ct[idx] ^= 0xFF;
+        assert!(aes256_gcm_decrypt(&key, &ct, b"").is_err());
+    }
+
+    #[test]
+    fn aes_gcm_input_too_short() {
+        let key = generate_random_key();
+        let result = aes256_gcm_decrypt(&key, &[0u8; 10], b"");
+        assert!(result.is_err());
+    }
+
+    // ── Keywrap ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn keywrap_roundtrip() {
+        let wrapping_key = generate_random_key();
+        let key_to_wrap = generate_random_key();
+        let aad = b"pildora:v1:vault-key";
+
+        let wrapped = aes256_gcm_keywrap(&wrapping_key, &key_to_wrap, aad).unwrap();
+        assert_eq!(wrapped.len(), WRAPPED_KEY_LEN);
+
+        let unwrapped = aes256_gcm_key_unwrap(&wrapping_key, &wrapped, aad).unwrap();
+        assert_eq!(unwrapped, key_to_wrap);
+    }
+
+    #[test]
+    fn keywrap_wrong_key_fails() {
+        let wk1 = generate_random_key();
+        let wk2 = generate_random_key();
+        let key = generate_random_key();
+        let aad = b"pildora:v1:vault-key";
+
+        let wrapped = aes256_gcm_keywrap(&wk1, &key, aad).unwrap();
+        assert!(aes256_gcm_key_unwrap(&wk2, &wrapped, aad).is_err());
+    }
+
+    #[test]
+    fn keywrap_wrong_aad_fails() {
+        let wk = generate_random_key();
+        let key = generate_random_key();
+
+        let wrapped = aes256_gcm_keywrap(&wk, &key, b"correct-aad").unwrap();
+        assert!(aes256_gcm_key_unwrap(&wk, &wrapped, b"wrong-aad").is_err());
+    }
+
+    #[test]
+    fn keywrap_bad_length_fails() {
+        let wk = generate_random_key();
+        assert!(aes256_gcm_key_unwrap(&wk, &[0u8; 59], b"").is_err());
+        assert!(aes256_gcm_key_unwrap(&wk, &[0u8; 61], b"").is_err());
+    }
+
+    #[test]
+    fn keywrap_output_is_60_bytes() {
+        let wk = generate_random_key();
+        let key = generate_random_key();
+        let wrapped = aes256_gcm_keywrap(&wk, &key, b"").unwrap();
+        assert_eq!(wrapped.len(), 60);
+    }
+
+    // ── X25519 ───────────────────────────────────────────────────────────
+
+    #[test]
+    fn x25519_shared_secret_agreement() {
+        let (sk_a, pk_a) = x25519_keypair();
+        let (sk_b, pk_b) = x25519_keypair();
+
+        let shared_ab = x25519_diffie_hellman(&sk_a, &pk_b);
+        let shared_ba = x25519_diffie_hellman(&sk_b, &pk_a);
+        assert_eq!(shared_ab, shared_ba, "DH shared secrets must agree");
+    }
+
+    #[test]
+    fn x25519_different_keypairs_different_secrets() {
+        let (sk_a, _pk_a) = x25519_keypair();
+        let (sk_b, _pk_b) = x25519_keypair();
+        let (_, pk_c) = x25519_keypair();
+
+        let s1 = x25519_diffie_hellman(&sk_a, &pk_c);
+        let s2 = x25519_diffie_hellman(&sk_b, &pk_c);
+        assert_ne!(s1, s2);
+    }
+
+    #[test]
+    fn x25519_public_key_roundtrip() {
+        let (_sk, pk) = x25519_keypair();
+        let bytes = *pk.as_bytes();
+        let pk2 = X25519PublicKey::from_bytes(bytes);
+        assert_eq!(pk, pk2);
+    }
+
+    #[test]
+    fn x25519_secret_key_debug_redacted() {
+        let (sk, _) = x25519_keypair();
+        let debug = format!("{sk:?}");
+        assert_eq!(debug, "X25519SecretKey([REDACTED])");
+    }
+
+    // ── BLAKE2b ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn blake2b_deterministic() {
+        let h1 = blake2b_hash(b"hello");
+        let h2 = blake2b_hash(b"hello");
+        assert_eq!(h1, h2);
+    }
+
+    #[test]
+    fn blake2b_different_inputs() {
+        let h1 = blake2b_hash(b"hello");
+        let h2 = blake2b_hash(b"world");
+        assert_ne!(h1, h2);
+    }
+
+    #[test]
+    fn blake2b_known_empty_hash() {
+        // BLAKE2b-256 of empty input
+        let h = blake2b_hash(b"");
+        // Known value: BLAKE2b-256("")
+        assert_eq!(h.len(), 32);
+        // Verify it's consistent (no randomness)
+        assert_eq!(h, blake2b_hash(b""));
+    }
+
+    #[test]
+    fn blake2b_mac_roundtrip() {
+        let key = generate_random_key();
+        let mac1 = blake2b_mac(&key, b"data").unwrap();
+        let mac2 = blake2b_mac(&key, b"data").unwrap();
+        assert_eq!(mac1, mac2);
+    }
+
+    #[test]
+    fn blake2b_mac_different_keys() {
+        let k1 = generate_random_key();
+        let k2 = generate_random_key();
+        let m1 = blake2b_mac(&k1, b"data").unwrap();
+        let m2 = blake2b_mac(&k2, b"data").unwrap();
+        assert_ne!(m1, m2);
+    }
+
+    // ── Salt / random generation ─────────────────────────────────────────
+
+    #[test]
+    fn salt_length() {
+        let salt = generate_salt();
+        assert_eq!(salt.len(), 16);
+    }
+
+    #[test]
+    fn salt_randomness() {
+        let s1 = generate_salt();
+        let s2 = generate_salt();
+        assert_ne!(s1, s2, "two random salts should differ");
+    }
+
+    #[test]
+    fn random_key_length() {
+        let key = generate_random_key();
+        assert_eq!(key.len(), 32);
+    }
+
+    #[test]
+    fn random_key_uniqueness() {
+        let k1 = generate_random_key();
+        let k2 = generate_random_key();
+        assert_ne!(k1, k2);
+    }
+}

--- a/crypto/src/vault.rs
+++ b/crypto/src/vault.rs
@@ -1,14 +1,558 @@
-//! Vault operations — key generation, wrapping, and item encryption.
+//! Item-level encryption and decryption.
 //!
-//! Each vault has its own symmetric key (VK). Each item within a vault has
-//! its own item key (IK), wrapped by the VK. This module will provide the
-//! high-level API for vault lifecycle operations.
+//! Provides the high-level API that CLI, iOS, and web call directly to
+//! encrypt and decrypt vault items (medications, dose logs, schedules, etc.).
 //!
-//! Implementation is tracked in issues #7 and #8.
+//! ## Encrypted Blob Format (v1)
+//!
+//! ```text
+//! [version: 1][nonce: 12][ciphertext: var][tag: 16][wrapped_item_key: 60]
+//! ```
+//!
+//! - **version** — enables future schema migrations on the client side.
+//! - **nonce + ciphertext + tag** — AES-256-GCM output from encrypting the
+//!   padded plaintext with a per-item key.
+//! - **wrapped item key** — the random item key, wrapped by the vault key.
+//!
+//! ## Padding
+//!
+//! Final blob sizes are padded to fixed-size buckets (512 B, 2 KiB, 8 KiB,
+//! 32 KiB) to prevent size-based inference about the encrypted content.
+//! The plaintext is prefixed with its original length (4 bytes, little-endian)
+//! and zero-padded so the entire blob lands in the target bucket.
+//! Items that exceed the largest bucket are stored without padding.
 
-// Vault operations will be implemented in issue #7 (key hierarchy) and
-// issue #8 (item encryption). This module is a placeholder that ensures
-// the crate structure compiles.
+use serde::{Serialize, de::DeserializeOwned};
+use zeroize::Zeroize;
 
-/// Placeholder for vault identifier type.
+use crate::error::{CryptoError, Result};
+use crate::key_hierarchy::{self, VaultKey, WrappedItemKey};
+use crate::primitives::{self, NONCE_LEN, TAG_LEN, WRAPPED_KEY_LEN};
+
+/// Vault identifier type.
 pub type VaultId = uuid::Uuid;
+
+// ── Blob constants ───────────────────────────────────────────────────────────
+
+/// Encrypted blob version byte.
+const BLOB_VERSION: u8 = crate::BLOB_VERSION;
+
+/// Fixed overhead in every blob: version + nonce + tag + wrapped item key.
+const BLOB_OVERHEAD: usize = 1 + NONCE_LEN + TAG_LEN + WRAPPED_KEY_LEN;
+
+/// Length prefix for the original plaintext (u32 little-endian).
+const LENGTH_PREFIX: usize = 4;
+
+/// Padding size buckets for the **final blob** (not plaintext).
+const SIZE_BUCKETS: &[usize] = &[512, 2048, 8192, 32768];
+
+/// AAD used for item encryption (domain separation).
+const AAD_ITEM_BLOB: &[u8] = b"pildora:v1:item-blob";
+
+// ── `EncryptedBlob` ──────────────────────────────────────────────────────────
+
+/// An encrypted item blob ready for storage or sync.
+///
+/// The blob is self-contained: it carries the wrapped item key so that only the
+/// vault key is needed to decrypt it.
+#[derive(Clone, Debug)]
+pub struct EncryptedBlob {
+    data: Vec<u8>,
+}
+
+impl EncryptedBlob {
+    /// Minimum valid blob size: version + nonce + tag + wrapped key.
+    const MIN_LEN: usize = BLOB_OVERHEAD;
+
+    /// Serialize the blob to its wire representation.
+    #[must_use]
+    pub fn to_bytes(&self) -> &[u8] {
+        &self.data
+    }
+
+    /// Deserialize a blob from its wire representation.
+    pub fn from_bytes(data: Vec<u8>) -> Result<Self> {
+        if data.len() < Self::MIN_LEN {
+            return Err(CryptoError::Decryption("blob too short".into()));
+        }
+        if data[0] != BLOB_VERSION {
+            return Err(CryptoError::UnsupportedBlobVersion { version: data[0] });
+        }
+        Ok(Self { data })
+    }
+
+    /// The blob version byte.
+    #[must_use]
+    pub fn version(&self) -> u8 {
+        self.data[0]
+    }
+
+    /// Total size in bytes.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    /// Whether the blob is empty (always false for valid blobs).
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+}
+
+// ── Core encrypt / decrypt ───────────────────────────────────────────────────
+
+/// Encrypt arbitrary plaintext into an [`EncryptedBlob`].
+///
+/// Generates a random per-item key, encrypts the padded plaintext, wraps the
+/// item key with the vault key, and assembles the blob.
+pub fn item_encrypt(plaintext: &[u8], vault_key: &VaultKey) -> Result<EncryptedBlob> {
+    if plaintext.len() > u32::MAX as usize {
+        return Err(CryptoError::Encryption(
+            "plaintext exceeds maximum size (4 GiB)".into(),
+        ));
+    }
+
+    // Generate random item key
+    let ik = key_hierarchy::generate_item_key();
+
+    // Pad plaintext with length prefix
+    let padded = pad_plaintext(plaintext);
+
+    // Encrypt padded plaintext with item key
+    let encrypted = primitives::aes256_gcm_encrypt(ik.as_bytes(), &padded, AAD_ITEM_BLOB)?;
+
+    // Wrap item key with vault key
+    let wrapped_ik = key_hierarchy::wrap_item_key(&ik, vault_key)?;
+
+    // Assemble blob: version || encrypted || wrapped_ik
+    let blob_len = 1 + encrypted.len() + WRAPPED_KEY_LEN;
+    let mut data = Vec::with_capacity(blob_len);
+    data.push(BLOB_VERSION);
+    data.extend_from_slice(&encrypted);
+    data.extend_from_slice(&wrapped_ik.0);
+
+    Ok(EncryptedBlob { data })
+}
+
+/// Decrypt an [`EncryptedBlob`] back to plaintext.
+pub fn item_decrypt(blob: &EncryptedBlob, vault_key: &VaultKey) -> Result<Vec<u8>> {
+    let data = &blob.data;
+
+    // Check version
+    if data[0] != BLOB_VERSION {
+        return Err(CryptoError::UnsupportedBlobVersion { version: data[0] });
+    }
+
+    // Split: version (1) || encrypted (...) || wrapped_ik (60)
+    let encrypted_end = data.len() - WRAPPED_KEY_LEN;
+    let encrypted = &data[1..encrypted_end];
+    let wrapped_ik_bytes = &data[encrypted_end..];
+
+    // Unwrap item key
+    let wrapped_ik = WrappedItemKey(wrapped_ik_bytes.to_vec());
+    let ik = key_hierarchy::unwrap_item_key(&wrapped_ik, vault_key)?;
+
+    // Decrypt
+    let mut padded = primitives::aes256_gcm_decrypt(ik.as_bytes(), encrypted, AAD_ITEM_BLOB)?;
+
+    // Unpad
+    let result = unpad_plaintext(&padded)?;
+    padded.zeroize();
+
+    Ok(result)
+}
+
+// ── Typed JSON encryption helpers ────────────────────────────────────────────
+
+/// Encrypt a serializable value as JSON inside an [`EncryptedBlob`].
+pub fn encrypt_json<T: Serialize>(value: &T, vault_key: &VaultKey) -> Result<EncryptedBlob> {
+    let json = serde_json::to_vec(value).map_err(|e| CryptoError::Serialization(e.to_string()))?;
+    item_encrypt(&json, vault_key)
+}
+
+/// Decrypt an [`EncryptedBlob`] and deserialize the JSON payload.
+pub fn decrypt_json<T: DeserializeOwned>(blob: &EncryptedBlob, vault_key: &VaultKey) -> Result<T> {
+    let mut plaintext = item_decrypt(blob, vault_key)?;
+    let result =
+        serde_json::from_slice(&plaintext).map_err(|e| CryptoError::Serialization(e.to_string()));
+    plaintext.zeroize();
+    result
+}
+
+// ── Padding ──────────────────────────────────────────────────────────────────
+
+/// Choose the target padded-plaintext size so the final blob fits in a bucket.
+fn target_padded_size(plaintext_len: usize) -> usize {
+    let needed_blob = BLOB_OVERHEAD + LENGTH_PREFIX + plaintext_len;
+    for &bucket in SIZE_BUCKETS {
+        if needed_blob <= bucket {
+            // Padded plaintext = bucket - overhead (version + nonce + tag + wrapped_key)
+            return bucket - BLOB_OVERHEAD;
+        }
+    }
+    // Larger than all buckets — no padding, just length-prefix
+    LENGTH_PREFIX + plaintext_len
+}
+
+/// Prepend a 4-byte length prefix and zero-pad to the target size.
+fn pad_plaintext(plaintext: &[u8]) -> Vec<u8> {
+    let target = target_padded_size(plaintext.len());
+    // Safe: max plaintext is bounded by bucket sizes (<= ~32KB for padded,
+    // and items >4GB would exhaust memory long before reaching this code.
+    #[allow(clippy::cast_possible_truncation)]
+    let len_bytes = (plaintext.len() as u32).to_le_bytes();
+    let mut padded = Vec::with_capacity(target);
+    padded.extend_from_slice(&len_bytes);
+    padded.extend_from_slice(plaintext);
+    padded.resize(target, 0);
+    padded
+}
+
+/// Remove padding and extract original plaintext.
+fn unpad_plaintext(padded: &[u8]) -> Result<Vec<u8>> {
+    if padded.len() < LENGTH_PREFIX {
+        return Err(CryptoError::Decryption("padded data too short".into()));
+    }
+
+    let len = u32::from_le_bytes([padded[0], padded[1], padded[2], padded[3]]) as usize;
+    if LENGTH_PREFIX + len > padded.len() {
+        return Err(CryptoError::Decryption("invalid plaintext length".into()));
+    }
+
+    Ok(padded[LENGTH_PREFIX..LENGTH_PREFIX + len].to_vec())
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::key_hierarchy::generate_vault_key;
+
+    // ── Helper domain types for testing ──────────────────────────────────
+
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, serde::Deserialize)]
+    struct Medication {
+        name: String,
+        dosage: String,
+        frequency: String,
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, serde::Deserialize)]
+    struct DoseLog {
+        medication_id: String,
+        taken_at: String,
+        notes: Option<String>,
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, serde::Deserialize)]
+    struct Schedule {
+        medication_id: String,
+        times: Vec<String>,
+        days: Vec<String>,
+    }
+
+    #[derive(Debug, Clone, PartialEq, Eq, Serialize, serde::Deserialize)]
+    struct Inventory {
+        medication_id: String,
+        count: u32,
+        refill_date: Option<String>,
+    }
+
+    // ── Basic roundtrip ──────────────────────────────────────────────────
+
+    #[test]
+    fn encrypt_decrypt_roundtrip_empty() {
+        let vk = generate_vault_key();
+        let blob = item_encrypt(b"", &vk).unwrap();
+        let pt = item_decrypt(&blob, &vk).unwrap();
+        assert!(pt.is_empty());
+    }
+
+    #[test]
+    fn encrypt_decrypt_roundtrip_small() {
+        let vk = generate_vault_key();
+        let data = b"hello, world!";
+        let blob = item_encrypt(data, &vk).unwrap();
+        let pt = item_decrypt(&blob, &vk).unwrap();
+        assert_eq!(pt, data);
+    }
+
+    #[test]
+    fn encrypt_decrypt_roundtrip_1kb() {
+        let vk = generate_vault_key();
+        let data = vec![0xAB; 1024];
+        let blob = item_encrypt(&data, &vk).unwrap();
+        let pt = item_decrypt(&blob, &vk).unwrap();
+        assert_eq!(pt, data);
+    }
+
+    #[test]
+    fn encrypt_decrypt_roundtrip_large() {
+        let vk = generate_vault_key();
+        let data = vec![0xCD; 40_000]; // Exceeds all buckets
+        let blob = item_encrypt(&data, &vk).unwrap();
+        let pt = item_decrypt(&blob, &vk).unwrap();
+        assert_eq!(pt, data);
+    }
+
+    // ── Ciphertext uniqueness ────────────────────────────────────────────
+
+    #[test]
+    fn two_encryptions_differ() {
+        let vk = generate_vault_key();
+        let blob1 = item_encrypt(b"same data", &vk).unwrap();
+        let blob2 = item_encrypt(b"same data", &vk).unwrap();
+        assert_ne!(
+            blob1.to_bytes(),
+            blob2.to_bytes(),
+            "random nonce + random IK must produce different blobs"
+        );
+    }
+
+    // ── Tamper detection ─────────────────────────────────────────────────
+
+    #[test]
+    fn tamper_ciphertext_fails() {
+        let vk = generate_vault_key();
+        let blob = item_encrypt(b"sensitive", &vk).unwrap();
+        let mut data = blob.data.clone();
+        // Flip a byte in the ciphertext area (after version + nonce)
+        data[NONCE_LEN + 3] ^= 0xFF;
+        let tampered = EncryptedBlob { data };
+        assert!(item_decrypt(&tampered, &vk).is_err());
+    }
+
+    #[test]
+    fn tamper_wrapped_key_fails() {
+        let vk = generate_vault_key();
+        let blob = item_encrypt(b"sensitive", &vk).unwrap();
+        let mut data = blob.data.clone();
+        // Flip a byte in the wrapped key area
+        let last = data.len() - 1;
+        data[last] ^= 0xFF;
+        let tampered = EncryptedBlob { data };
+        assert!(item_decrypt(&tampered, &vk).is_err());
+    }
+
+    #[test]
+    fn wrong_vault_key_fails() {
+        let vk1 = generate_vault_key();
+        let vk2 = generate_vault_key();
+        let blob = item_encrypt(b"secret", &vk1).unwrap();
+        assert!(item_decrypt(&blob, &vk2).is_err());
+    }
+
+    // ── Blob version ─────────────────────────────────────────────────────
+
+    #[test]
+    fn blob_version_is_1() {
+        let vk = generate_vault_key();
+        let blob = item_encrypt(b"test", &vk).unwrap();
+        assert_eq!(blob.version(), 1);
+    }
+
+    #[test]
+    fn blob_wrong_version_rejected() {
+        let vk = generate_vault_key();
+        let blob = item_encrypt(b"test", &vk).unwrap();
+        let mut data = blob.data.clone();
+        data[0] = 99;
+        let result = EncryptedBlob::from_bytes(data);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn blob_too_short_rejected() {
+        let result = EncryptedBlob::from_bytes(vec![1, 2, 3]);
+        assert!(result.is_err());
+    }
+
+    // ── Blob serialization roundtrip ─────────────────────────────────────
+
+    #[test]
+    fn blob_bytes_roundtrip() {
+        let vk = generate_vault_key();
+        let blob = item_encrypt(b"roundtrip", &vk).unwrap();
+        let bytes = blob.to_bytes().to_vec();
+        let restored = EncryptedBlob::from_bytes(bytes).unwrap();
+        let pt = item_decrypt(&restored, &vk).unwrap();
+        assert_eq!(pt, b"roundtrip");
+    }
+
+    // ── Padding ──────────────────────────────────────────────────────────
+
+    #[test]
+    fn padding_small_fits_512_bucket() {
+        let vk = generate_vault_key();
+        let blob = item_encrypt(b"small", &vk).unwrap();
+        assert_eq!(blob.len(), 512);
+    }
+
+    #[test]
+    fn padding_empty_fits_512_bucket() {
+        let vk = generate_vault_key();
+        let blob = item_encrypt(b"", &vk).unwrap();
+        assert_eq!(blob.len(), 512);
+    }
+
+    #[test]
+    fn padding_medium_fits_2kb_bucket() {
+        let vk = generate_vault_key();
+        // 512 - 89 - 4 = 419 max plaintext for 512 bucket
+        let data = vec![0xAA; 420]; // Just over → should bump to 2KB
+        let blob = item_encrypt(&data, &vk).unwrap();
+        assert_eq!(blob.len(), 2048);
+    }
+
+    #[test]
+    fn padding_8kb_bucket() {
+        let vk = generate_vault_key();
+        // 2048 - 89 - 4 = 1955 max for 2KB bucket
+        let data = vec![0xBB; 1956];
+        let blob = item_encrypt(&data, &vk).unwrap();
+        assert_eq!(blob.len(), 8192);
+    }
+
+    #[test]
+    fn padding_32kb_bucket() {
+        let vk = generate_vault_key();
+        // 8192 - 89 - 4 = 8099 max for 8KB bucket
+        let data = vec![0xCC; 8100];
+        let blob = item_encrypt(&data, &vk).unwrap();
+        assert_eq!(blob.len(), 32768);
+    }
+
+    #[test]
+    fn padding_exceeds_all_buckets_no_padding() {
+        let vk = generate_vault_key();
+        // 32768 - 89 - 4 = 32675 max for 32KB bucket
+        let data = vec![0xDD; 32676];
+        let blob = item_encrypt(&data, &vk).unwrap();
+        // No bucket padding — exact size
+        let expected = 1 + NONCE_LEN + LENGTH_PREFIX + data.len() + TAG_LEN + WRAPPED_KEY_LEN;
+        assert_eq!(blob.len(), expected);
+    }
+
+    #[test]
+    fn padding_preserves_data() {
+        let vk = generate_vault_key();
+        for size in [
+            0, 1, 100, 419, 420, 1955, 1956, 8099, 8100, 32675, 32676, 50_000,
+        ] {
+            let data = vec![0xEE; size];
+            let blob = item_encrypt(&data, &vk).unwrap();
+            let pt = item_decrypt(&blob, &vk).unwrap();
+            assert_eq!(pt.len(), size, "roundtrip failed for size {size}");
+            assert_eq!(pt, data, "data mismatch for size {size}");
+        }
+    }
+
+    #[test]
+    fn all_blobs_in_correct_buckets() {
+        let vk = generate_vault_key();
+        let valid_sizes = [512, 2048, 8192, 32768];
+        for size in [0, 1, 50, 200, 419] {
+            let blob = item_encrypt(&vec![0; size], &vk).unwrap();
+            assert!(
+                valid_sizes.contains(&blob.len()),
+                "blob len {} not in buckets for plaintext size {size}",
+                blob.len()
+            );
+        }
+    }
+
+    // ── Typed JSON encryption ────────────────────────────────────────────
+
+    #[test]
+    fn encrypt_medication_roundtrip() {
+        let vk = generate_vault_key();
+        let med = Medication {
+            name: "Lisinopril".into(),
+            dosage: "10mg".into(),
+            frequency: "daily".into(),
+        };
+        let blob = encrypt_json(&med, &vk).unwrap();
+        let decrypted: Medication = decrypt_json(&blob, &vk).unwrap();
+        assert_eq!(med, decrypted);
+    }
+
+    #[test]
+    fn encrypt_dose_log_roundtrip() {
+        let vk = generate_vault_key();
+        let log = DoseLog {
+            medication_id: "med-001".into(),
+            taken_at: "2026-04-25T10:30:00Z".into(),
+            notes: Some("Taken with food".into()),
+        };
+        let blob = encrypt_json(&log, &vk).unwrap();
+        let decrypted: DoseLog = decrypt_json(&blob, &vk).unwrap();
+        assert_eq!(log, decrypted);
+    }
+
+    #[test]
+    fn encrypt_schedule_roundtrip() {
+        let vk = generate_vault_key();
+        let schedule = Schedule {
+            medication_id: "med-002".into(),
+            times: vec!["08:00".into(), "20:00".into()],
+            days: vec!["Mon".into(), "Wed".into(), "Fri".into()],
+        };
+        let blob = encrypt_json(&schedule, &vk).unwrap();
+        let decrypted: Schedule = decrypt_json(&blob, &vk).unwrap();
+        assert_eq!(schedule, decrypted);
+    }
+
+    #[test]
+    fn encrypt_inventory_roundtrip() {
+        let vk = generate_vault_key();
+        let inv = Inventory {
+            medication_id: "med-003".into(),
+            count: 28,
+            refill_date: Some("2026-05-15".into()),
+        };
+        let blob = encrypt_json(&inv, &vk).unwrap();
+        let decrypted: Inventory = decrypt_json(&blob, &vk).unwrap();
+        assert_eq!(inv, decrypted);
+    }
+
+    #[test]
+    fn encrypt_json_wrong_key_fails() {
+        let vk1 = generate_vault_key();
+        let vk2 = generate_vault_key();
+        let med = Medication {
+            name: "Secret Med".into(),
+            dosage: "5mg".into(),
+            frequency: "daily".into(),
+        };
+        let blob = encrypt_json(&med, &vk1).unwrap();
+        let result: Result<Medication> = decrypt_json(&blob, &vk2);
+        assert!(result.is_err());
+    }
+
+    // ── Internal padding helpers ─────────────────────────────────────────
+
+    #[test]
+    fn pad_unpad_roundtrip() {
+        for size in [0, 1, 10, 100, 1000, 10_000, 50_000] {
+            let data = vec![0xFF; size];
+            let padded = pad_plaintext(&data);
+            let unpadded = unpad_plaintext(&padded).unwrap();
+            assert_eq!(unpadded, data, "pad/unpad failed for size {size}");
+        }
+    }
+
+    #[test]
+    fn unpad_too_short_fails() {
+        assert!(unpad_plaintext(&[1, 2, 3]).is_err());
+    }
+
+    #[test]
+    fn unpad_invalid_length_fails() {
+        // Claim length of 100 but only 4 bytes of padding data
+        let mut data = vec![0; 8];
+        data[..4].copy_from_slice(&100u32.to_le_bytes());
+        assert!(unpad_plaintext(&data).is_err());
+    }
+}


### PR DESCRIPTION
## Description

Implement the full `pildora-crypto` encryption stack: cryptographic primitives, key hierarchy, and item-level encryption.

### What's included

- **Core primitives** (`primitives.rs`): Argon2id key derivation (64 MiB / 3 iter / p=1), HKDF-SHA-256 sub-key derivation, AES-256-GCM encrypt/decrypt with random 96-bit nonces, AES-256-GCM key wrapping with AAD domain separation, X25519 key pair generation and Diffie-Hellman, BLAKE2b-256 hashing and keyed MAC, cryptographic salt and key generation via `OsRng`
- **Key hierarchy** (`key_hierarchy.rs`): Password-to-master-key derivation, master key to auth key + master encryption key via HKDF, vault key and item key generation/wrap/unwrap with AAD tags (`pildora:v1:wrapped-vault-key`, `pildora:v1:wrapped-item-key`), vault re-keying (re-wrap all item keys under a new vault key), recovery key with Crockford Base32 encoding and checksum for transcription safety
- **Item encryption** (`vault.rs`): `EncryptedBlob` format v1 (`[version:1][nonce:12][ciphertext:var][tag:16][wrapped_ik:60]`), per-item random key generation, blob padding to fixed-size buckets (512 B, 2 KiB, 8 KiB, 32 KiB) to prevent size-based inference, generic `encrypt_json<T>`/`decrypt_json<T>` helpers for any `Serialize`/`DeserializeOwned` type, 4 GiB plaintext size guard
- **79 unit tests** covering RFC test vectors (HKDF RFC 5869), roundtrips at various payload sizes (0 B to 1 MiB), wrong-key/tampered-data rejection, padding bucket correctness, domain separation enforcement, typed JSON encryption for all entity types, and debug redaction of all key types

All key material uses `Zeroize` + `ZeroizeOnDrop`. No `unsafe` code. Pure Rust via `RustCrypto` crates.

## Related Issues

Closes #6, closes #7, closes #8

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Component

- [x] `crypto/` — Encryption library

## Privacy Checklist

- [x] No plaintext user health data is sent to or stored on the server
- [x] No new metadata exposure introduced (or documented if unavoidable)
- [x] Drug/health features include appropriate disclaimers and source attribution
- [x] Any new external service interaction is documented in the trust boundary model

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] Tests pass (if applicable)
- [x] I have updated documentation (if applicable)
