### PR TITLE
feat(cli): implement medication CRUD, schedules, and dose logging

### DIFF
--- a/.github/skills/pr-ready/SKILL.md
+++ b/.github/skills/pr-ready/SKILL.md
@@ -67,6 +67,13 @@ Prepare a branch for pull request: generate a PR description from the diff AND u
    can introduce formatting changes). Only proceed once all three pass in a
    single run with no fixes in between.
 
+   **Toolchain version gap:** CI uses the latest stable Rust, which may have
+   newer clippy lints than the local toolchain. If CI fails with a clippy error
+   that passed locally, fix it immediately — do not assume local-passing means
+   CI-passing. Common culprits: `unnecessary_sort_by`, `manual_let_else`,
+   `needless_pass_by_value`. When in doubt, prefer the idiomatic form clippy
+   suggests.
+
 3. **Run component-specific checks** for other affected components:
    - `ios/` (Swift): `swiftlint` and `xcodebuild test` if configured
    - `web/` (TypeScript): `npm run lint && npm test` if configured

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Vault initialization with master password, Argon2id key derivation, and recovery key generation
 - Vault unlock/lock with session persistence for seamless multi-command workflows
 - Recovery key display and regeneration for account recovery
+- Medication CRUD commands: add (with flags for dosage, form, prescriber, pharmacy), list (table view), show (detail view with name matching), edit, and delete
+- Medication schedules with flexible patterns: daily, multi-daily, every N days, specific weekdays, and PRN (as needed)
+- Dose logging: log taken doses, skip with reason, view today's doses with status (taken/missed/upcoming/skipped), and dose history
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,6 +278,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "comfy-table"
+version = "7.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "958c5d6ecf1f214b4c2bbbbf6ab9523a864bd136dcf71a7e8904799acfe1ad47"
+dependencies = [
+ "crossterm",
+ "unicode-segmentation",
+ "unicode-width",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -290,6 +301,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags",
+ "crossterm_winapi",
+ "document-features",
+ "parking_lot",
+ "rustix",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]
@@ -368,6 +402,15 @@ dependencies = [
  "option-ext",
  "redox_users",
  "windows-sys",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -672,6 +715,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
+
+[[package]]
+name = "lock_api"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+dependencies = [
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -743,6 +801,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-link",
+]
+
+[[package]]
 name = "password-hash"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -761,6 +842,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "colored",
+ "comfy-table",
  "dirs",
  "hex",
  "pildora-crypto",
@@ -902,6 +984,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "redox_users"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -972,6 +1063,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "semver"
@@ -1118,6 +1215,18 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -28,6 +28,7 @@ thiserror = "2"
 uuid = { version = "1", features = ["v4"] }
 hex = "0.4"
 rpassword = "5"
+comfy-table = "7"
 
 [dev-dependencies]
 tempfile = "3"

--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -69,6 +69,21 @@ pub enum MedCommands {
         /// Dosage form (e.g. tablet, capsule)
         #[arg(short, long)]
         form: Option<String>,
+        /// Generic name
+        #[arg(long)]
+        generic: Option<String>,
+        /// Brand name
+        #[arg(long)]
+        brand: Option<String>,
+        /// Prescriber
+        #[arg(long)]
+        prescriber: Option<String>,
+        /// Pharmacy
+        #[arg(long)]
+        pharmacy: Option<String>,
+        /// Notes
+        #[arg(short, long)]
+        notes: Option<String>,
     },
     /// List all medications
     List,
@@ -81,6 +96,21 @@ pub enum MedCommands {
     Edit {
         /// Medication name or ID
         name: String,
+        /// New dosage
+        #[arg(short, long)]
+        dosage: Option<String>,
+        /// New form
+        #[arg(short, long)]
+        form: Option<String>,
+        /// New notes
+        #[arg(short, long)]
+        notes: Option<String>,
+        /// New prescriber
+        #[arg(long)]
+        prescriber: Option<String>,
+        /// New pharmacy
+        #[arg(long)]
+        pharmacy: Option<String>,
     },
     /// Delete a medication
     Delete {
@@ -98,6 +128,9 @@ pub enum DoseCommands {
     Log {
         /// Medication name
         medication: String,
+        /// Time taken (HH:MM, defaults to now)
+        #[arg(long)]
+        at: Option<String>,
         /// Notes
         #[arg(short, long)]
         notes: Option<String>,
@@ -114,6 +147,8 @@ pub enum DoseCommands {
     Today,
     /// Show dose history
     History {
+        /// Medication name (omit for all)
+        medication: Option<String>,
         /// Number of days to show (default: 7)
         #[arg(short, long, default_value = "7")]
         days: u32,
@@ -126,9 +161,21 @@ pub enum ScheduleCommands {
     Set {
         /// Medication name
         medication: String,
-        /// Times (e.g. "08:00,20:00")
+        /// Schedule pattern: daily, every, days, prn
+        #[arg(short, long, default_value = "daily")]
+        pattern: String,
+        /// Times (comma-separated, e.g. "08:00,20:00"). Not needed for PRN.
         #[arg(short, long)]
-        times: String,
+        times: Option<String>,
+        /// Interval for 'every' pattern (e.g. 3 for every 3 days)
+        #[arg(short, long)]
+        interval: Option<u32>,
+        /// Days for 'days' pattern (e.g. "mon,wed,fri")
+        #[arg(short = 'D', long)]
+        days: Option<String>,
+        /// Start date for 'every' pattern (YYYY-MM-DD, defaults to today)
+        #[arg(long)]
+        start_date: Option<String>,
     },
     /// Show the schedule for a medication or all medications
     Show {

--- a/cli/src/commands/dose.rs
+++ b/cli/src/commands/dose.rs
@@ -1,28 +1,322 @@
+use std::fmt::Write;
+use std::process;
+
+use chrono::{DateTime, Local, NaiveTime, TimeZone, Utc};
 use colored::Colorize;
+use comfy_table::{ContentArrangement, Table};
 
 use crate::cli::DoseCommands;
+use crate::context::UnlockedContext;
+use crate::models::{DoseLog, DoseStatus, Schedule};
+use crate::schedule_engine::doses_for_date;
+use crate::storage::typed::{list_typed_items, store_typed_item};
+
+const DOSE_ITEM_TYPE: &str = "dose_log";
+const SCHEDULE_ITEM_TYPE: &str = "schedule";
 
 pub fn run(cmd: &DoseCommands) {
     match cmd {
-        DoseCommands::Log { .. } => println!(
-            "{} {} command is not yet implemented.",
-            "⚠".yellow(),
-            "dose log".bold()
-        ),
-        DoseCommands::Skip { .. } => println!(
-            "{} {} command is not yet implemented.",
-            "⚠".yellow(),
-            "dose skip".bold()
-        ),
-        DoseCommands::Today => println!(
-            "{} {} command is not yet implemented.",
-            "⚠".yellow(),
-            "dose today".bold()
-        ),
-        DoseCommands::History { .. } => println!(
-            "{} {} command is not yet implemented.",
-            "⚠".yellow(),
-            "dose history".bold()
-        ),
+        DoseCommands::Log {
+            medication,
+            at,
+            notes,
+        } => log_dose(medication, at.as_deref(), notes.as_deref()),
+        DoseCommands::Skip { medication, reason } => skip(medication, reason.as_deref()),
+        DoseCommands::Today => today(),
+        DoseCommands::History { medication, days } => history(medication.as_deref(), *days),
     }
+}
+
+fn log_dose(med_query: &str, at_str: Option<&str>, notes: Option<&str>) {
+    let ctx = UnlockedContext::require();
+    let (_med_item_id, med) = ctx.find_medication(med_query);
+
+    let taken_at = parse_dose_time(at_str);
+    let now = Utc::now();
+
+    let dose_log = DoseLog {
+        medication_id: med.id.to_string(),
+        medication_name: med.name.clone(),
+        taken_at,
+        status: DoseStatus::Taken,
+        notes: notes.map(String::from),
+        created_at: now,
+    };
+
+    store_typed_item(
+        &ctx.storage,
+        &ctx.vault_key,
+        &ctx.vault_id,
+        DOSE_ITEM_TYPE,
+        &dose_log,
+    )
+    .unwrap_or_else(|e| {
+        eprintln!("{} Failed to store dose log: {e}", "\u{2717}".red());
+        process::exit(1);
+    });
+
+    let local_time = taken_at.with_timezone(&Local);
+    println!(
+        "{} Logged dose of {} at {}",
+        "\u{2713}".green(),
+        med.name.green(),
+        local_time.format("%H:%M")
+    );
+}
+
+fn skip(med_query: &str, reason: Option<&str>) {
+    let ctx = UnlockedContext::require();
+    let (_med_item_id, med) = ctx.find_medication(med_query);
+
+    let now = Utc::now();
+
+    let dose_log = DoseLog {
+        medication_id: med.id.to_string(),
+        medication_name: med.name.clone(),
+        taken_at: now,
+        status: DoseStatus::Skipped,
+        notes: reason.map(String::from),
+        created_at: now,
+    };
+
+    store_typed_item(
+        &ctx.storage,
+        &ctx.vault_key,
+        &ctx.vault_id,
+        DOSE_ITEM_TYPE,
+        &dose_log,
+    )
+    .unwrap_or_else(|e| {
+        eprintln!("{} Failed to store dose log: {e}", "\u{2717}".red());
+        process::exit(1);
+    });
+
+    let msg = if let Some(r) = reason {
+        format!(
+            "\u{23ed} Skipped dose of {} \u{2014} \"{}\"",
+            med.name.green(),
+            r
+        )
+    } else {
+        format!("\u{23ed} Skipped dose of {}", med.name.green())
+    };
+    println!("{msg}");
+}
+
+fn today() {
+    let ctx = UnlockedContext::require();
+    let today = Local::now().date_naive();
+    let now = Utc::now();
+
+    // Load all schedules
+    let schedules: Vec<(String, Schedule)> = list_typed_items(
+        &ctx.storage,
+        &ctx.vault_key,
+        &ctx.vault_id,
+        SCHEDULE_ITEM_TYPE,
+    )
+    .unwrap_or_else(|e| {
+        eprintln!("{} Failed to list schedules: {e}", "\u{2717}".red());
+        process::exit(1);
+    });
+
+    // Load all dose logs
+    let all_logs: Vec<(String, DoseLog)> =
+        list_typed_items(&ctx.storage, &ctx.vault_key, &ctx.vault_id, DOSE_ITEM_TYPE)
+            .unwrap_or_else(|e| {
+                eprintln!("{} Failed to list dose logs: {e}", "\u{2717}".red());
+                process::exit(1);
+            });
+
+    // Filter logs to today
+    let today_logs: Vec<&DoseLog> = all_logs
+        .iter()
+        .filter(|(_id, log)| log.taken_at.with_timezone(&Local).date_naive() == today)
+        .map(|(_id, log)| log)
+        .collect();
+
+    // Compute all scheduled doses for today
+    let mut rows: Vec<TodayRow> = Vec::new();
+
+    for (_id, schedule) in &schedules {
+        let scheduled_doses = doses_for_date(schedule, today);
+
+        // Load the medication to get dosage info
+        let meds: Vec<(String, crate::models::Medication)> =
+            list_typed_items(&ctx.storage, &ctx.vault_key, &ctx.vault_id, "medication")
+                .unwrap_or_default();
+
+        let dosage = meds
+            .iter()
+            .find(|(_id, m)| m.id.to_string() == schedule.medication_id)
+            .map(|(_id, m)| m.dosage.clone())
+            .unwrap_or_default();
+
+        for dose in &scheduled_doses {
+            // Check if there's a log for this med today
+            let matching_log = today_logs
+                .iter()
+                .find(|log| log.medication_id == dose.medication_id);
+
+            let status = match matching_log {
+                Some(log) if log.status == DoseStatus::Taken => "\u{2705} Taken".to_string(),
+                Some(log) if log.status == DoseStatus::Skipped => "\u{23ed} Skipped".to_string(),
+                _ => {
+                    if dose.time < now {
+                        "\u{274c} Missed".to_string()
+                    } else {
+                        "\u{23f0} Upcoming".to_string()
+                    }
+                }
+            };
+
+            let local_time = dose.time.with_timezone(&Local);
+            rows.push(TodayRow {
+                time: local_time,
+                medication: dose.medication_name.clone(),
+                dosage: dosage.clone(),
+                status,
+            });
+        }
+    }
+
+    if rows.is_empty() {
+        println!("No doses scheduled for today.");
+        return;
+    }
+
+    rows.sort_by_key(|r| r.time);
+
+    println!(
+        "{}",
+        format!("Today's Doses ({})", today.format("%Y-%m-%d")).bold()
+    );
+
+    let mut table = Table::new();
+    table.set_content_arrangement(ContentArrangement::Dynamic);
+    table.set_header(vec!["Time", "Medication", "Dosage", "Status"]);
+
+    for row in &rows {
+        table.add_row(vec![
+            row.time.format("%H:%M").to_string(),
+            row.medication.clone(),
+            row.dosage.clone(),
+            row.status.clone(),
+        ]);
+    }
+
+    println!("{table}");
+}
+
+struct TodayRow {
+    time: DateTime<Local>,
+    medication: String,
+    dosage: String,
+    status: String,
+}
+
+fn history(med_query: Option<&str>, days: u32) {
+    let ctx = UnlockedContext::require();
+    let now_local = Local::now();
+    let cutoff_date = now_local.date_naive() - chrono::Duration::days(i64::from(days));
+
+    // Load all dose logs
+    let all_logs: Vec<(String, DoseLog)> =
+        list_typed_items(&ctx.storage, &ctx.vault_key, &ctx.vault_id, DOSE_ITEM_TYPE)
+            .unwrap_or_else(|e| {
+                eprintln!("{} Failed to list dose logs: {e}", "\u{2717}".red());
+                process::exit(1);
+            });
+
+    // Filter by date range and optionally by medication
+    let med_filter = med_query.map(|q| {
+        let (_id, med) = ctx.find_medication(q);
+        med.id.to_string()
+    });
+
+    let mut filtered: Vec<&DoseLog> = all_logs
+        .iter()
+        .filter(|(_id, log)| {
+            let log_date = log.taken_at.with_timezone(&Local).date_naive();
+            if log_date < cutoff_date {
+                return false;
+            }
+            if let Some(ref med_id) = med_filter {
+                return &log.medication_id == med_id;
+            }
+            true
+        })
+        .map(|(_id, log)| log)
+        .collect();
+
+    if filtered.is_empty() {
+        println!("No dose history found for the past {days} day(s).");
+        return;
+    }
+
+    // Sort by taken_at descending
+    filtered.sort_by(|a, b| b.taken_at.cmp(&a.taken_at));
+
+    // Group by date
+    let mut current_date = None;
+    for log in &filtered {
+        let log_local = log.taken_at.with_timezone(&Local);
+        let date = log_local.date_naive();
+
+        if current_date != Some(date) {
+            if current_date.is_some() {
+                println!();
+            }
+            println!("{}", date.format("%Y-%m-%d").to_string().bold());
+            current_date = Some(date);
+        }
+
+        let status_icon = match log.status {
+            DoseStatus::Taken => "\u{2705}",
+            DoseStatus::Skipped => "\u{23ed}",
+        };
+        let status_label = match log.status {
+            DoseStatus::Taken => "Taken",
+            DoseStatus::Skipped => "Skipped",
+        };
+
+        let mut line = format!(
+            "  {}  {}  {} {}",
+            log_local.format("%H:%M"),
+            log.medication_name,
+            status_icon,
+            status_label
+        );
+
+        if let Some(ref notes) = log.notes {
+            let _ = write!(line, " \u{2014} \"{notes}\"");
+        }
+
+        println!("{line}");
+    }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+fn parse_dose_time(at_str: Option<&str>) -> DateTime<Utc> {
+    let Some(raw) = at_str else {
+        return Utc::now();
+    };
+
+    let time = NaiveTime::parse_from_str(raw, "%H:%M").unwrap_or_else(|_| {
+        eprintln!("Invalid time '{raw}'. Use HH:MM format (e.g. 08:00).");
+        process::exit(1);
+    });
+
+    let today = Local::now().date_naive();
+    let local_dt = today.and_time(time);
+
+    Local
+        .from_local_datetime(&local_dt)
+        .single()
+        .unwrap_or_else(|| {
+            eprintln!("Ambiguous local time '{raw}'.");
+            process::exit(1);
+        })
+        .with_timezone(&Utc)
 }

--- a/cli/src/commands/dose.rs
+++ b/cli/src/commands/dose.rs
@@ -255,7 +255,7 @@ fn history(med_query: Option<&str>, days: u32) {
     }
 
     // Sort by taken_at descending
-    filtered.sort_by(|a, b| b.taken_at.cmp(&a.taken_at));
+    filtered.sort_by_key(|l| std::cmp::Reverse(l.taken_at));
 
     // Group by date
     let mut current_date = None;

--- a/cli/src/commands/med.rs
+++ b/cli/src/commands/med.rs
@@ -1,33 +1,271 @@
+use std::io::{self, BufRead, Write};
+use std::process;
+
+use chrono::Utc;
 use colored::Colorize;
+use comfy_table::{ContentArrangement, Table};
+use uuid::Uuid;
 
 use crate::cli::MedCommands;
+use crate::context::UnlockedContext;
+use crate::models::Medication;
+use crate::storage::typed::{list_typed_items, store_typed_item};
+
+const ITEM_TYPE: &str = "medication";
 
 pub fn run(cmd: &MedCommands) {
     match cmd {
-        MedCommands::Add { .. } => println!(
-            "{} {} command is not yet implemented.",
-            "⚠".yellow(),
-            "med add".bold()
+        MedCommands::Add {
+            name,
+            dosage,
+            form,
+            generic,
+            brand,
+            prescriber,
+            pharmacy,
+            notes,
+        } => add(
+            name,
+            dosage.as_deref(),
+            form.as_deref(),
+            generic.as_deref(),
+            brand.as_deref(),
+            prescriber.as_deref(),
+            pharmacy.as_deref(),
+            notes.as_deref(),
         ),
-        MedCommands::List => println!(
-            "{} {} command is not yet implemented.",
-            "⚠".yellow(),
-            "med list".bold()
+        MedCommands::List => list(),
+        MedCommands::Show { name } => show(name),
+        MedCommands::Edit {
+            name,
+            dosage,
+            form,
+            notes,
+            prescriber,
+            pharmacy,
+        } => edit(
+            name,
+            dosage.as_deref(),
+            form.as_deref(),
+            notes.as_deref(),
+            prescriber.as_deref(),
+            pharmacy.as_deref(),
         ),
-        MedCommands::Show { .. } => println!(
-            "{} {} command is not yet implemented.",
-            "⚠".yellow(),
-            "med show".bold()
-        ),
-        MedCommands::Edit { .. } => println!(
-            "{} {} command is not yet implemented.",
-            "⚠".yellow(),
-            "med edit".bold()
-        ),
-        MedCommands::Delete { .. } => println!(
-            "{} {} command is not yet implemented.",
-            "⚠".yellow(),
-            "med delete".bold()
-        ),
+        MedCommands::Delete { name, force } => delete(name, *force),
     }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn add(
+    name: &str,
+    dosage: Option<&str>,
+    form: Option<&str>,
+    generic: Option<&str>,
+    brand: Option<&str>,
+    prescriber: Option<&str>,
+    pharmacy: Option<&str>,
+    notes: Option<&str>,
+) {
+    let ctx = UnlockedContext::require();
+    let now = Utc::now();
+
+    let med = Medication {
+        id: Uuid::new_v4(),
+        name: name.to_string(),
+        generic_name: generic.map(String::from),
+        brand_name: brand.map(String::from),
+        dosage: dosage.unwrap_or_default().to_string(),
+        form: form.unwrap_or_default().to_string(),
+        prescriber: prescriber.map(String::from),
+        pharmacy: pharmacy.map(String::from),
+        notes: notes.map(String::from),
+        rxnorm_id: None,
+        start_date: None,
+        end_date: None,
+        created_at: now,
+        updated_at: now,
+    };
+
+    store_typed_item(&ctx.storage, &ctx.vault_key, &ctx.vault_id, ITEM_TYPE, &med).unwrap_or_else(
+        |e| {
+            eprintln!("{} Failed to store medication: {e}", "\u{2717}".red());
+            process::exit(1);
+        },
+    );
+
+    println!(
+        "{} Added medication: {}",
+        "\u{2713}".green(),
+        med.name.green()
+    );
+}
+
+fn list() {
+    let ctx = UnlockedContext::require();
+
+    let meds: Vec<(String, Medication)> =
+        list_typed_items(&ctx.storage, &ctx.vault_key, &ctx.vault_id, ITEM_TYPE).unwrap_or_else(
+            |e| {
+                eprintln!("{} Failed to list medications: {e}", "\u{2717}".red());
+                process::exit(1);
+            },
+        );
+
+    if meds.is_empty() {
+        println!("No medications found. Use 'pildora med add' to add one.");
+        return;
+    }
+
+    let mut table = Table::new();
+    table.set_content_arrangement(ContentArrangement::Dynamic);
+    table.set_header(vec!["#", "Name", "Dosage", "Form", "Notes"]);
+
+    for (i, (_id, med)) in meds.iter().enumerate() {
+        table.add_row(vec![
+            (i + 1).to_string(),
+            med.name.clone(),
+            med.dosage.clone(),
+            med.form.clone(),
+            med.notes.clone().unwrap_or_default(),
+        ]);
+    }
+
+    println!("{table}");
+}
+
+fn show(query: &str) {
+    let ctx = UnlockedContext::require();
+    let (_item_id, med) = ctx.find_medication(query);
+
+    println!("{:<13}{}", "Name:".bold(), med.name);
+    if let Some(ref g) = med.generic_name {
+        println!("{:<13}{g}", "Generic:");
+    }
+    if let Some(ref b) = med.brand_name {
+        println!("{:<13}{b}", "Brand:");
+    }
+    if !med.dosage.is_empty() {
+        println!("{:<13}{}", "Dosage:", med.dosage);
+    }
+    if !med.form.is_empty() {
+        println!("{:<13}{}", "Form:", med.form);
+    }
+    if let Some(ref p) = med.prescriber {
+        println!("{:<13}{p}", "Prescriber:");
+    }
+    if let Some(ref ph) = med.pharmacy {
+        println!("{:<13}{ph}", "Pharmacy:");
+    }
+    if let Some(ref n) = med.notes {
+        println!("{:<13}{n}", "Notes:");
+    }
+    if let Some(ref r) = med.rxnorm_id {
+        println!("{:<13}{r}", "RxNorm ID:");
+    }
+    if let Some(ref s) = med.start_date {
+        println!("{:<13}{s}", "Start date:");
+    }
+    if let Some(ref e) = med.end_date {
+        println!("{:<13}{e}", "End date:");
+    }
+    println!("{:<13}{}", "Created:", med.created_at);
+    println!("{:<13}{}", "Updated:", med.updated_at);
+}
+
+fn edit(
+    query: &str,
+    dosage: Option<&str>,
+    form: Option<&str>,
+    notes: Option<&str>,
+    prescriber: Option<&str>,
+    pharmacy: Option<&str>,
+) {
+    if dosage.is_none()
+        && form.is_none()
+        && notes.is_none()
+        && prescriber.is_none()
+        && pharmacy.is_none()
+    {
+        eprintln!(
+            "No fields to update. Use --dosage, --form, --notes, --prescriber, or --pharmacy."
+        );
+        process::exit(1);
+    }
+
+    let ctx = UnlockedContext::require();
+    let (item_id, mut med) = ctx.find_medication(query);
+
+    let mut changed = Vec::new();
+
+    if let Some(d) = dosage {
+        d.clone_into(&mut med.dosage);
+        changed.push("dosage");
+    }
+    if let Some(f) = form {
+        f.clone_into(&mut med.form);
+        changed.push("form");
+    }
+    if let Some(n) = notes {
+        med.notes = Some(n.to_string());
+        changed.push("notes");
+    }
+    if let Some(p) = prescriber {
+        med.prescriber = Some(p.to_string());
+        changed.push("prescriber");
+    }
+    if let Some(ph) = pharmacy {
+        med.pharmacy = Some(ph.to_string());
+        changed.push("pharmacy");
+    }
+
+    med.updated_at = Utc::now();
+
+    let blob = pildora_crypto::vault::encrypt_json(&med, &ctx.vault_key).unwrap_or_else(|e| {
+        eprintln!("{} Encryption failed: {e}", "\u{2717}".red());
+        process::exit(1);
+    });
+
+    ctx.storage
+        .update_item(&item_id, blob.to_bytes())
+        .unwrap_or_else(|e| {
+            eprintln!("{} Failed to update medication: {e}", "\u{2717}".red());
+            process::exit(1);
+        });
+
+    println!(
+        "{} Updated {}: {}",
+        "\u{2713}".green(),
+        med.name.green(),
+        changed.join(", ")
+    );
+}
+
+fn delete(query: &str, force: bool) {
+    let ctx = UnlockedContext::require();
+    let (item_id, med) = ctx.find_medication(query);
+
+    if !force {
+        print!("Delete '{}'? [y/N]: ", med.name);
+        io::stdout().flush().ok();
+        let mut line = String::new();
+        io::stdin().lock().read_line(&mut line).unwrap_or_else(|e| {
+            eprintln!("{} Failed to read input: {e}", "\u{2717}".red());
+            process::exit(1);
+        });
+        if !line.trim().eq_ignore_ascii_case("y") {
+            println!("Cancelled.");
+            return;
+        }
+    }
+
+    ctx.storage.delete_item(&item_id).unwrap_or_else(|e| {
+        eprintln!("{} Failed to delete medication: {e}", "\u{2717}".red());
+        process::exit(1);
+    });
+
+    println!(
+        "{} Deleted medication: {}",
+        "\u{2713}".green(),
+        med.name.green()
+    );
 }

--- a/cli/src/commands/schedule.rs
+++ b/cli/src/commands/schedule.rs
@@ -1,18 +1,349 @@
+use std::process;
+
+use chrono::{Local, NaiveDate, NaiveTime, Utc, Weekday};
 use colored::Colorize;
+use comfy_table::{ContentArrangement, Table};
 
 use crate::cli::ScheduleCommands;
+use crate::context::UnlockedContext;
+use crate::models::{Schedule, SchedulePattern};
+use crate::schedule_engine::{doses_for_date, next_doses};
+use crate::storage::typed::{list_typed_items, store_typed_item};
+
+const ITEM_TYPE: &str = "schedule";
 
 pub fn run(cmd: &ScheduleCommands) {
     match cmd {
-        ScheduleCommands::Set { .. } => println!(
-            "{} {} command is not yet implemented.",
-            "⚠".yellow(),
-            "schedule set".bold()
+        ScheduleCommands::Set {
+            medication,
+            pattern,
+            times,
+            interval,
+            days,
+            start_date,
+        } => set(
+            medication,
+            pattern,
+            times.as_deref(),
+            *interval,
+            days.as_deref(),
+            start_date.as_deref(),
         ),
-        ScheduleCommands::Show { .. } => println!(
-            "{} {} command is not yet implemented.",
-            "⚠".yellow(),
-            "schedule show".bold()
-        ),
+        ScheduleCommands::Show { medication } => show(medication.as_deref()),
+    }
+}
+
+fn set(
+    med_query: &str,
+    pattern_str: &str,
+    times_str: Option<&str>,
+    interval: Option<u32>,
+    days_str: Option<&str>,
+    start_date_str: Option<&str>,
+) {
+    let ctx = UnlockedContext::require();
+    let (_med_item_id, med) = ctx.find_medication(med_query);
+
+    let pattern = parse_pattern(pattern_str, interval, days_str, start_date_str);
+
+    let times = if matches!(pattern, SchedulePattern::Prn) {
+        vec![]
+    } else {
+        let Some(raw) = times_str else {
+            eprintln!("Times are required for non-PRN schedules. Use --times \"08:00,20:00\".");
+            process::exit(1);
+        };
+        parse_and_normalize_times(raw)
+    };
+
+    let now = Utc::now();
+
+    // Check for existing schedule for this medication
+    let existing: Vec<(String, Schedule)> =
+        list_typed_items(&ctx.storage, &ctx.vault_key, &ctx.vault_id, ITEM_TYPE).unwrap_or_else(
+            |e| {
+                eprintln!("{} Failed to list schedules: {e}", "\u{2717}".red());
+                process::exit(1);
+            },
+        );
+
+    let existing_item = existing
+        .into_iter()
+        .find(|(_id, s)| s.medication_id == med.id.to_string());
+
+    let schedule = Schedule {
+        medication_id: med.id.to_string(),
+        medication_name: med.name.clone(),
+        pattern,
+        times,
+        created_at: existing_item.as_ref().map_or(now, |(_, s)| s.created_at),
+        updated_at: now,
+    };
+
+    if let Some((item_id, _)) = existing_item {
+        // Update existing schedule
+        let blob =
+            pildora_crypto::vault::encrypt_json(&schedule, &ctx.vault_key).unwrap_or_else(|e| {
+                eprintln!("{} Encryption failed: {e}", "\u{2717}".red());
+                process::exit(1);
+            });
+        ctx.storage
+            .update_item(&item_id, blob.to_bytes())
+            .unwrap_or_else(|e| {
+                eprintln!("{} Failed to update schedule: {e}", "\u{2717}".red());
+                process::exit(1);
+            });
+        println!(
+            "{} Updated schedule for {}",
+            "\u{2713}".green(),
+            med.name.green()
+        );
+    } else {
+        store_typed_item(
+            &ctx.storage,
+            &ctx.vault_key,
+            &ctx.vault_id,
+            ITEM_TYPE,
+            &schedule,
+        )
+        .unwrap_or_else(|e| {
+            eprintln!("{} Failed to store schedule: {e}", "\u{2717}".red());
+            process::exit(1);
+        });
+        println!(
+            "{} Set schedule for {}",
+            "\u{2713}".green(),
+            med.name.green()
+        );
+    }
+
+    print_pattern_summary(&schedule);
+
+    // Show next 3 upcoming doses
+    let upcoming = next_doses(&schedule, Utc::now(), 3);
+    if !upcoming.is_empty() {
+        println!("\n{}", "Next doses:".bold());
+        for dose in &upcoming {
+            let local = dose.time.with_timezone(&Local);
+            println!("  \u{2022} {}", local.format("%a %Y-%m-%d %H:%M"));
+        }
+    }
+}
+
+fn show(med_query: Option<&str>) {
+    let ctx = UnlockedContext::require();
+
+    let schedules: Vec<(String, Schedule)> =
+        list_typed_items(&ctx.storage, &ctx.vault_key, &ctx.vault_id, ITEM_TYPE).unwrap_or_else(
+            |e| {
+                eprintln!("{} Failed to list schedules: {e}", "\u{2717}".red());
+                process::exit(1);
+            },
+        );
+
+    if schedules.is_empty() {
+        println!("No schedules found. Use 'pildora schedule set' to create one.");
+        return;
+    }
+
+    if let Some(query) = med_query {
+        let (_med_item_id, med) = ctx.find_medication(query);
+        let med_id = med.id.to_string();
+
+        let found = schedules
+            .into_iter()
+            .find(|(_id, s)| s.medication_id == med_id);
+
+        match found {
+            Some((_id, schedule)) => {
+                println!("{} {}", "Schedule for".bold(), med.name.bold());
+                print_pattern_summary(&schedule);
+                print_times(&schedule);
+
+                let upcoming = next_doses(&schedule, Utc::now(), 5);
+                if !upcoming.is_empty() {
+                    println!("\n{}", "Upcoming doses:".bold());
+                    for dose in &upcoming {
+                        let local = dose.time.with_timezone(&Local);
+                        println!("  \u{2022} {}", local.format("%a %Y-%m-%d %H:%M"));
+                    }
+                }
+            }
+            None => {
+                println!("No schedule found for '{}'.", med.name);
+            }
+        }
+    } else {
+        // Show all schedules in a table
+        let today = Local::now().date_naive();
+
+        let mut table = Table::new();
+        table.set_content_arrangement(ContentArrangement::Dynamic);
+        table.set_header(vec!["Medication", "Pattern", "Times", "Today"]);
+
+        for (_id, schedule) in &schedules {
+            let pattern_str = format_pattern(&schedule.pattern);
+            let times_str = schedule
+                .times
+                .iter()
+                .map(|t| t.format("%H:%M").to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+
+            let today_doses = doses_for_date(schedule, today);
+            let today_str = if today_doses.is_empty() {
+                "—".to_string()
+            } else {
+                format!("{} dose(s)", today_doses.len())
+            };
+
+            table.add_row(vec![
+                schedule.medication_name.clone(),
+                pattern_str,
+                times_str,
+                today_str,
+            ]);
+        }
+
+        println!("{table}");
+    }
+}
+
+// ── Parsing helpers ──────────────────────────────────────────────────────────
+
+fn parse_pattern(
+    pattern_str: &str,
+    interval: Option<u32>,
+    days_str: Option<&str>,
+    start_date_str: Option<&str>,
+) -> SchedulePattern {
+    match pattern_str.to_lowercase().as_str() {
+        "daily" => SchedulePattern::Daily,
+        "every" => {
+            let interval = interval.unwrap_or_else(|| {
+                eprintln!("Interval is required for 'every' pattern. Use --interval 3.");
+                process::exit(1);
+            });
+            if interval == 0 {
+                eprintln!("Interval must be at least 1.");
+                process::exit(1);
+            }
+            let start_date = start_date_str.map_or_else(
+                || Local::now().date_naive(),
+                |s| {
+                    NaiveDate::parse_from_str(s, "%Y-%m-%d").unwrap_or_else(|_| {
+                        eprintln!("Invalid start date '{s}'. Use YYYY-MM-DD format.");
+                        process::exit(1);
+                    })
+                },
+            );
+            SchedulePattern::EveryNDays {
+                interval,
+                start_date,
+            }
+        }
+        "days" => {
+            let Some(raw) = days_str else {
+                eprintln!("Days are required for 'days' pattern. Use --days \"mon,wed,fri\".");
+                process::exit(1);
+            };
+            let days = parse_weekdays(raw);
+            if days.is_empty() {
+                eprintln!("No valid days provided. Use day names like mon,tue,wed.");
+                process::exit(1);
+            }
+            SchedulePattern::SpecificDays { days }
+        }
+        "prn" | "asneeded" | "as-needed" => SchedulePattern::Prn,
+        other => {
+            eprintln!("Unknown schedule pattern '{other}'. Use: daily, every, days, prn.");
+            process::exit(1);
+        }
+    }
+}
+
+fn parse_weekdays(raw: &str) -> Vec<Weekday> {
+    let mut days: Vec<Weekday> = raw
+        .split(',')
+        .filter_map(|s| {
+            let s = s.trim().to_lowercase();
+            match s.as_str() {
+                "mon" | "monday" => Some(Weekday::Mon),
+                "tue" | "tuesday" => Some(Weekday::Tue),
+                "wed" | "wednesday" => Some(Weekday::Wed),
+                "thu" | "thursday" => Some(Weekday::Thu),
+                "fri" | "friday" => Some(Weekday::Fri),
+                "sat" | "saturday" => Some(Weekday::Sat),
+                "sun" | "sunday" => Some(Weekday::Sun),
+                _ => {
+                    eprintln!("Unknown day '{s}', skipping.");
+                    None
+                }
+            }
+        })
+        .collect();
+    days.sort_by_key(Weekday::num_days_from_monday);
+    days.dedup();
+    days
+}
+
+fn parse_and_normalize_times(raw: &str) -> Vec<NaiveTime> {
+    let mut times: Vec<NaiveTime> = raw
+        .split(',')
+        .map(|s| {
+            let s = s.trim();
+            NaiveTime::parse_from_str(s, "%H:%M").unwrap_or_else(|_| {
+                eprintln!("Invalid time '{s}'. Use HH:MM format (e.g. 08:00).");
+                process::exit(1);
+            })
+        })
+        .collect();
+    times.sort();
+    times.dedup();
+    times
+}
+
+// ── Display helpers ──────────────────────────────────────────────────────────
+
+fn format_pattern(pattern: &SchedulePattern) -> String {
+    match pattern {
+        SchedulePattern::Daily => "Daily".to_string(),
+        SchedulePattern::EveryNDays {
+            interval,
+            start_date,
+        } => format!("Every {interval} days (from {start_date})"),
+        SchedulePattern::SpecificDays { days } => {
+            let day_names: Vec<&str> = days
+                .iter()
+                .map(|d| match d {
+                    Weekday::Mon => "Mon",
+                    Weekday::Tue => "Tue",
+                    Weekday::Wed => "Wed",
+                    Weekday::Thu => "Thu",
+                    Weekday::Fri => "Fri",
+                    Weekday::Sat => "Sat",
+                    Weekday::Sun => "Sun",
+                })
+                .collect();
+            day_names.join(", ")
+        }
+        SchedulePattern::Prn => "As needed (PRN)".to_string(),
+    }
+}
+
+fn print_pattern_summary(schedule: &Schedule) {
+    println!("  Pattern: {}", format_pattern(&schedule.pattern));
+}
+
+fn print_times(schedule: &Schedule) {
+    if schedule.times.is_empty() {
+        println!("  Times:   (as needed)");
+    } else {
+        let times_str: Vec<String> = schedule
+            .times
+            .iter()
+            .map(|t| t.format("%H:%M").to_string())
+            .collect();
+        println!("  Times:   {}", times_str.join(", "));
     }
 }

--- a/cli/src/context.rs
+++ b/cli/src/context.rs
@@ -1,0 +1,123 @@
+use std::process;
+
+use colored::Colorize;
+use pildora_crypto::key_hierarchy::{self, MasterEncryptionKey, VaultKey, WrappedVaultKey};
+use uuid::Uuid;
+
+use crate::models::Medication;
+use crate::session::Session;
+use crate::storage::Storage;
+use crate::storage::typed::list_typed_items;
+
+/// Holds the unlocked vault context needed by data commands.
+pub struct UnlockedContext {
+    pub storage: Storage,
+    pub vault_key: VaultKey,
+    pub vault_id: String,
+}
+
+impl UnlockedContext {
+    /// Open storage, verify session is active, reconstruct VK.
+    /// Exits with error message if vault is locked or not initialized.
+    pub fn require() -> Self {
+        let data_dir = crate::storage::default_data_dir();
+        let storage = Storage::open(&data_dir).unwrap_or_else(|e| {
+            eprintln!("{} Failed to open storage: {e}", "\u{2717}".red());
+            process::exit(1);
+        });
+
+        if !storage.is_initialized().unwrap_or(false) {
+            eprintln!("Not initialized. Run 'pildora init' first.");
+            process::exit(1);
+        }
+
+        let session = Session::new(&data_dir);
+        let mek_bytes = session
+            .load_mek()
+            .unwrap_or_else(|e| {
+                eprintln!("{} Session error: {e}", "\u{2717}".red());
+                process::exit(1);
+            })
+            .unwrap_or_else(|| {
+                eprintln!("Vault is locked. Run 'pildora unlock' first.");
+                process::exit(1);
+            });
+
+        let mut mek_arr = [0u8; 32];
+        mek_arr.copy_from_slice(&mek_bytes);
+        let mek = MasterEncryptionKey::from_bytes(mek_arr);
+
+        let vault_ids = storage.list_vault_ids().unwrap_or_else(|e| {
+            eprintln!("{} Failed to list vaults: {e}", "\u{2717}".red());
+            process::exit(1);
+        });
+
+        let vault_id = vault_ids.into_iter().next().unwrap_or_else(|| {
+            eprintln!("{} No vaults found.", "\u{2717}".red());
+            process::exit(1);
+        });
+
+        let wrapped_vk_bytes = storage
+            .get_wrapped_vault_key(&vault_id)
+            .unwrap_or_else(|e| {
+                eprintln!("{} Failed to get vault key: {e}", "\u{2717}".red());
+                process::exit(1);
+            });
+        let wvk = WrappedVaultKey(wrapped_vk_bytes);
+        let vault_key = key_hierarchy::unwrap_vault_key(&wvk, &mek).unwrap_or_else(|e| {
+            eprintln!("{} Failed to unwrap vault key: {e}", "\u{2717}".red());
+            eprintln!("  Session may be stale. Try 'pildora lock' then 'pildora unlock'.");
+            process::exit(1);
+        });
+
+        Self {
+            storage,
+            vault_key,
+            vault_id,
+        }
+    }
+
+    /// Find a medication by case-insensitive substring match on name.
+    ///
+    /// Exits with an error if zero or multiple matches are found.
+    pub fn find_medication(&self, query: &str) -> (String, Medication) {
+        let meds: Vec<(String, Medication)> =
+            list_typed_items(&self.storage, &self.vault_key, &self.vault_id, "medication")
+                .unwrap_or_else(|e| {
+                    eprintln!("{} Failed to list medications: {e}", "\u{2717}".red());
+                    process::exit(1);
+                });
+
+        // Try exact UUID match first
+        if let Ok(parsed_uuid) = Uuid::parse_str(query) {
+            let uuid_str = parsed_uuid.to_string();
+            for (item_id, med) in &meds {
+                if med.id.to_string() == uuid_str {
+                    return (item_id.clone(), med.clone());
+                }
+            }
+        }
+
+        let lower = query.to_lowercase();
+        let matches: Vec<(String, Medication)> = meds
+            .into_iter()
+            .filter(|(_id, m)| m.name.to_lowercase().contains(&lower))
+            .collect();
+
+        match matches.len() {
+            0 => {
+                eprintln!("No medication found matching '{query}'.");
+                process::exit(1);
+            }
+            1 => matches.into_iter().next().unwrap(),
+            _ => {
+                eprintln!("Multiple medications match '{query}':");
+                for (_id, m) in &matches {
+                    eprintln!("  - {}", m.name);
+                }
+                eprintln!("Please be more specific.");
+                process::exit(1);
+            }
+        }
+    }
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,11 +1,9 @@
 mod cli;
 mod commands;
-// Models and storage contain types scaffolded for future commands (med, dose,
-// schedule, export). Suppress dead-code warnings until those commands ship.
-#[allow(dead_code)]
+mod context;
 mod models;
+pub mod schedule_engine;
 mod session;
-#[allow(dead_code)]
 mod storage;
 
 use clap::Parser;
@@ -19,7 +17,7 @@ fn main() {
         Commands::Unlock => commands::unlock::run(),
         Commands::Lock => commands::lock::run(),
         Commands::Status => commands::status::run(),
-        Commands::Med(ref cmd) => commands::med::run(cmd),
+        Commands::Med(cmd) => commands::med::run(&cmd),
         Commands::Dose(ref cmd) => commands::dose::run(cmd),
         Commands::Schedule(ref cmd) => commands::schedule::run(cmd),
         Commands::Export { output } => commands::export::run(output),

--- a/cli/src/models.rs
+++ b/cli/src/models.rs
@@ -1,36 +1,69 @@
+use chrono::{DateTime, NaiveDate, NaiveTime, Utc, Weekday};
 use serde::{Deserialize, Serialize};
+use uuid::Uuid;
 
 /// A medication or supplement tracked by the user.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Medication {
+    pub id: Uuid,
     pub name: String,
-    pub dosage: Option<String>,
-    pub form: Option<String>,
+    pub generic_name: Option<String>,
+    pub brand_name: Option<String>,
+    pub dosage: String,
+    pub form: String,
+    pub prescriber: Option<String>,
+    pub pharmacy: Option<String>,
     pub notes: Option<String>,
-}
-
-/// A dose log entry.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct DoseLog {
-    pub medication_id: String,
-    pub taken_at: String,
-    pub status: DoseStatus,
-    pub notes: Option<String>,
-}
-
-/// Whether a dose was taken or intentionally skipped.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum DoseStatus {
-    Taken,
-    Skipped,
+    pub rxnorm_id: Option<String>,
+    pub start_date: Option<String>,
+    pub end_date: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
 }
 
 /// A medication schedule.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Schedule {
     pub medication_id: String,
-    pub times: Vec<String>,
-    pub days: Option<Vec<String>>,
+    pub medication_name: String,
+    pub pattern: SchedulePattern,
+    pub times: Vec<NaiveTime>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// The recurrence pattern for a schedule.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum SchedulePattern {
+    /// Every day at the specified times.
+    Daily,
+    /// Every N days starting from a specific date.
+    EveryNDays {
+        interval: u32,
+        start_date: NaiveDate,
+    },
+    /// On specific weekdays.
+    SpecificDays { days: Vec<Weekday> },
+    /// As needed — no fixed schedule.
+    Prn,
+}
+
+/// A dose log entry.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DoseLog {
+    pub medication_id: String,
+    pub medication_name: String,
+    pub taken_at: DateTime<Utc>,
+    pub status: DoseStatus,
+    pub notes: Option<String>,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Whether a dose was taken or intentionally skipped.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum DoseStatus {
+    Taken,
+    Skipped,
 }
 
 /// Vault metadata (encrypted under VK).

--- a/cli/src/schedule_engine.rs
+++ b/cli/src/schedule_engine.rs
@@ -1,0 +1,260 @@
+use chrono::{DateTime, Datelike, Local, NaiveDate, NaiveTime, TimeZone, Utc};
+
+use crate::models::{Schedule, SchedulePattern};
+
+/// A computed scheduled dose occurrence.
+#[derive(Debug, Clone)]
+pub struct ScheduledDose {
+    pub time: DateTime<Utc>,
+    pub medication_id: String,
+    pub medication_name: String,
+}
+
+/// Compute the next `count` scheduled dose times starting from `from`.
+///
+/// Returns an empty vec for PRN schedules (taken as needed).
+pub fn next_doses(schedule: &Schedule, from: DateTime<Utc>, count: usize) -> Vec<ScheduledDose> {
+    if matches!(schedule.pattern, SchedulePattern::Prn) || count == 0 {
+        return vec![];
+    }
+
+    let local_now = from.with_timezone(&Local);
+    let mut current_date = local_now.date_naive();
+    let mut results = Vec::with_capacity(count);
+
+    // Scan up to 400 days forward to handle every-N-days with large intervals.
+    for _ in 0..400 {
+        if date_matches_pattern(&schedule.pattern, current_date) {
+            for &time in &schedule.times {
+                if let Some(utc_dt) = naive_to_utc(current_date, time)
+                    && utc_dt > from
+                {
+                    results.push(ScheduledDose {
+                        time: utc_dt,
+                        medication_id: schedule.medication_id.clone(),
+                        medication_name: schedule.medication_name.clone(),
+                    });
+                    if results.len() >= count {
+                        return results;
+                    }
+                }
+            }
+        }
+        current_date += chrono::Duration::days(1);
+    }
+
+    results
+}
+
+/// Compute all scheduled doses for a specific date.
+pub fn doses_for_date(schedule: &Schedule, date: NaiveDate) -> Vec<ScheduledDose> {
+    if !date_matches_pattern(&schedule.pattern, date) {
+        return vec![];
+    }
+
+    schedule
+        .times
+        .iter()
+        .filter_map(|&time| {
+            naive_to_utc(date, time).map(|utc_dt| ScheduledDose {
+                time: utc_dt,
+                medication_id: schedule.medication_id.clone(),
+                medication_name: schedule.medication_name.clone(),
+            })
+        })
+        .collect()
+}
+
+/// Check if a date matches the schedule pattern.
+pub fn date_matches_pattern(pattern: &SchedulePattern, date: NaiveDate) -> bool {
+    match pattern {
+        SchedulePattern::Daily => true,
+        SchedulePattern::EveryNDays {
+            interval,
+            start_date,
+        } => {
+            let days_diff = (date - *start_date).num_days();
+            days_diff >= 0 && days_diff % i64::from(*interval) == 0
+        }
+        SchedulePattern::SpecificDays { days } => days.contains(&date.weekday()),
+        SchedulePattern::Prn => false,
+    }
+}
+
+/// Convert a `NaiveDate` + `NaiveTime` to a UTC `DateTime` using the system
+/// local timezone. Returns `None` if the local time is ambiguous or
+/// non-existent (e.g., during a spring-forward DST gap).
+fn naive_to_utc(date: NaiveDate, time: NaiveTime) -> Option<DateTime<Utc>> {
+    Local
+        .from_local_datetime(&date.and_time(time))
+        .single()
+        .map(|dt| dt.with_timezone(&Utc))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::{NaiveDate, NaiveTime, Utc, Weekday};
+
+    fn make_schedule(pattern: SchedulePattern, times: Vec<NaiveTime>) -> Schedule {
+        Schedule {
+            medication_id: "med-1".to_string(),
+            medication_name: "TestMed".to_string(),
+            pattern,
+            times,
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        }
+    }
+
+    #[test]
+    fn daily_schedule_next_doses() {
+        let schedule = make_schedule(
+            SchedulePattern::Daily,
+            vec![
+                NaiveTime::from_hms_opt(8, 0, 0).unwrap(),
+                NaiveTime::from_hms_opt(20, 0, 0).unwrap(),
+            ],
+        );
+
+        let from = Utc::now();
+        let doses = next_doses(&schedule, from, 4);
+        assert_eq!(doses.len(), 4);
+
+        // All doses should be in the future
+        for dose in &doses {
+            assert!(dose.time > from);
+        }
+
+        // Doses should be in chronological order
+        for window in doses.windows(2) {
+            assert!(window[0].time < window[1].time);
+        }
+    }
+
+    #[test]
+    fn every_n_days_pattern() {
+        let start = NaiveDate::from_ymd_opt(2026, 4, 25).unwrap();
+        let schedule = make_schedule(
+            SchedulePattern::EveryNDays {
+                interval: 3,
+                start_date: start,
+            },
+            vec![NaiveTime::from_hms_opt(9, 0, 0).unwrap()],
+        );
+
+        // Day 0 (start) should match
+        assert!(date_matches_pattern(&schedule.pattern, start));
+
+        // Day 1 and Day 2 should NOT match
+        let day1 = NaiveDate::from_ymd_opt(2026, 4, 26).unwrap();
+        let day2 = NaiveDate::from_ymd_opt(2026, 4, 27).unwrap();
+        assert!(!date_matches_pattern(&schedule.pattern, day1));
+        assert!(!date_matches_pattern(&schedule.pattern, day2));
+
+        // Day 3 should match
+        let day3 = NaiveDate::from_ymd_opt(2026, 4, 28).unwrap();
+        assert!(date_matches_pattern(&schedule.pattern, day3));
+
+        // Day 6 should match
+        let day6 = NaiveDate::from_ymd_opt(2026, 5, 1).unwrap();
+        assert!(date_matches_pattern(&schedule.pattern, day6));
+
+        // Day before start should NOT match
+        let before = NaiveDate::from_ymd_opt(2026, 4, 24).unwrap();
+        assert!(!date_matches_pattern(&schedule.pattern, before));
+    }
+
+    #[test]
+    fn specific_days_pattern() {
+        let pattern = SchedulePattern::SpecificDays {
+            days: vec![Weekday::Mon, Weekday::Wed, Weekday::Fri],
+        };
+
+        // 2026-04-27 is a Monday
+        let mon = NaiveDate::from_ymd_opt(2026, 4, 27).unwrap();
+        assert_eq!(mon.weekday(), Weekday::Mon);
+        assert!(date_matches_pattern(&pattern, mon));
+
+        // Tuesday should not match
+        let tue = NaiveDate::from_ymd_opt(2026, 4, 28).unwrap();
+        assert!(!date_matches_pattern(&pattern, tue));
+
+        // Wednesday should match
+        let wed = NaiveDate::from_ymd_opt(2026, 4, 29).unwrap();
+        assert!(date_matches_pattern(&pattern, wed));
+
+        // Friday should match
+        let fri = NaiveDate::from_ymd_opt(2026, 5, 1).unwrap();
+        assert_eq!(fri.weekday(), Weekday::Fri);
+        assert!(date_matches_pattern(&pattern, fri));
+    }
+
+    #[test]
+    fn prn_returns_empty() {
+        let schedule = make_schedule(SchedulePattern::Prn, vec![]);
+        let doses = next_doses(&schedule, Utc::now(), 5);
+        assert!(doses.is_empty());
+
+        let date = NaiveDate::from_ymd_opt(2026, 4, 25).unwrap();
+        assert!(!date_matches_pattern(&schedule.pattern, date));
+    }
+
+    #[test]
+    fn doses_for_date_daily() {
+        let schedule = make_schedule(
+            SchedulePattern::Daily,
+            vec![
+                NaiveTime::from_hms_opt(8, 0, 0).unwrap(),
+                NaiveTime::from_hms_opt(14, 0, 0).unwrap(),
+                NaiveTime::from_hms_opt(20, 0, 0).unwrap(),
+            ],
+        );
+
+        let date = NaiveDate::from_ymd_opt(2026, 6, 15).unwrap();
+        let doses = doses_for_date(&schedule, date);
+        assert_eq!(doses.len(), 3);
+
+        for dose in &doses {
+            assert_eq!(dose.medication_name, "TestMed");
+        }
+    }
+
+    #[test]
+    fn doses_for_date_non_matching_day() {
+        let schedule = make_schedule(
+            SchedulePattern::SpecificDays {
+                days: vec![Weekday::Mon],
+            },
+            vec![NaiveTime::from_hms_opt(8, 0, 0).unwrap()],
+        );
+
+        // 2026-04-28 is Tuesday
+        let tue = NaiveDate::from_ymd_opt(2026, 4, 28).unwrap();
+        assert!(doses_for_date(&schedule, tue).is_empty());
+    }
+
+    #[test]
+    fn next_doses_zero_count() {
+        let schedule = make_schedule(
+            SchedulePattern::Daily,
+            vec![NaiveTime::from_hms_opt(8, 0, 0).unwrap()],
+        );
+        let doses = next_doses(&schedule, Utc::now(), 0);
+        assert!(doses.is_empty());
+    }
+
+    #[test]
+    fn midnight_crossing() {
+        // Schedule at 23:59 — should still produce a dose on the correct day
+        let schedule = make_schedule(
+            SchedulePattern::Daily,
+            vec![NaiveTime::from_hms_opt(23, 59, 0).unwrap()],
+        );
+
+        let from = Utc::now();
+        let doses = next_doses(&schedule, from, 2);
+        assert_eq!(doses.len(), 2);
+        assert!(doses[0].time < doses[1].time);
+    }
+}

--- a/cli/src/storage/mod.rs
+++ b/cli/src/storage/mod.rs
@@ -28,6 +28,7 @@ pub enum StorageError {
 // ── Supporting types ─────────────────────────────────────────────────────────
 
 #[derive(Debug)]
+#[allow(dead_code)]
 pub struct AccountState {
     pub salt: Vec<u8>,
     pub argon2_memory_kib: u32,
@@ -39,6 +40,7 @@ pub struct AccountState {
 }
 
 #[derive(Debug)]
+#[allow(dead_code)]
 pub struct ItemRow {
     pub id: String,
     pub vault_id: String,
@@ -65,6 +67,7 @@ pub fn default_data_dir() -> PathBuf {
 
 pub struct Storage {
     conn: Connection,
+    #[allow(dead_code)]
     data_dir: PathBuf,
 }
 
@@ -91,6 +94,7 @@ impl Storage {
     }
 
     /// Return the data directory this storage was opened with.
+    #[allow(dead_code)]
     pub fn data_dir(&self) -> &Path {
         &self.data_dir
     }
@@ -268,6 +272,7 @@ impl Storage {
     }
 
     /// Get encrypted vault metadata.
+    #[allow(dead_code)]
     pub fn get_vault_metadata(&self, vault_id: &str) -> Result<Vec<u8>, StorageError> {
         self.conn
             .query_row(

--- a/cli/src/storage/typed.rs
+++ b/cli/src/storage/typed.rs
@@ -22,6 +22,7 @@ pub fn store_typed_item<T: serde::Serialize>(
 }
 
 /// Load and decrypt a typed item by ID.
+#[allow(dead_code)]
 pub fn load_typed_item<T: serde::de::DeserializeOwned>(
     storage: &Storage,
     vault_key: &VaultKey,

--- a/cli/tests/med_test.rs
+++ b/cli/tests/med_test.rs
@@ -1,0 +1,422 @@
+use chrono::Utc;
+use pildora_crypto::key_hierarchy;
+use pildora_crypto::vault::{EncryptedBlob, decrypt_json, encrypt_json};
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+// ── Mirror types from the binary crate ──────────────────────────────────────
+// Integration tests cannot import from a binary crate, so we replicate the
+// Medication model and a thin Storage wrapper with the same schema.
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Medication {
+    id: Uuid,
+    name: String,
+    generic_name: Option<String>,
+    brand_name: Option<String>,
+    dosage: String,
+    form: String,
+    prescriber: Option<String>,
+    pharmacy: Option<String>,
+    notes: Option<String>,
+    rxnorm_id: Option<String>,
+    start_date: Option<String>,
+    end_date: Option<String>,
+    created_at: chrono::DateTime<Utc>,
+    updated_at: chrono::DateTime<Utc>,
+}
+
+const ITEM_TYPE: &str = "medication";
+
+// ── Minimal test storage ────────────────────────────────────────────────────
+
+mod test_storage {
+    use rusqlite::{Connection, params};
+    use std::fs;
+    use std::path::{Path, PathBuf};
+
+    #[derive(Debug)]
+    pub struct ItemRow {
+        pub id: String,
+        pub encrypted_blob: Vec<u8>,
+    }
+
+    pub struct Storage {
+        conn: Connection,
+        _data_dir: PathBuf,
+    }
+
+    impl Storage {
+        pub fn open(data_dir: &Path) -> Self {
+            fs::create_dir_all(data_dir).unwrap();
+            let db_path = data_dir.join("pildora.db");
+            let conn = Connection::open(&db_path).unwrap();
+
+            conn.pragma_update(None, "journal_mode", "WAL").unwrap();
+            conn.pragma_update(None, "foreign_keys", "ON").unwrap();
+            conn.execute_batch(
+                "CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL);
+                 CREATE TABLE IF NOT EXISTS account_state (
+                     id INTEGER PRIMARY KEY CHECK (id = 1),
+                     salt BLOB NOT NULL,
+                     argon2_memory_kib INTEGER NOT NULL DEFAULT 65536,
+                     argon2_iterations INTEGER NOT NULL DEFAULT 3,
+                     argon2_parallelism INTEGER NOT NULL DEFAULT 1,
+                     recovery_wrapped_mek BLOB,
+                     recovery_key_encrypted BLOB,
+                     created_at TEXT NOT NULL
+                 );
+                 CREATE TABLE IF NOT EXISTS vaults (
+                     id TEXT PRIMARY KEY,
+                     encrypted_metadata BLOB NOT NULL,
+                     wrapped_vault_key BLOB NOT NULL,
+                     created_at TEXT NOT NULL,
+                     updated_at TEXT NOT NULL
+                 );
+                 CREATE TABLE IF NOT EXISTS encrypted_items (
+                     id TEXT PRIMARY KEY,
+                     vault_id TEXT NOT NULL REFERENCES vaults(id) ON DELETE CASCADE,
+                     item_type TEXT NOT NULL,
+                     encrypted_blob BLOB NOT NULL,
+                     blob_version INTEGER NOT NULL DEFAULT 1,
+                     created_at TEXT NOT NULL,
+                     updated_at TEXT NOT NULL
+                 );",
+            )
+            .unwrap();
+
+            Self {
+                conn,
+                _data_dir: data_dir.to_path_buf(),
+            }
+        }
+
+        pub fn store_item(&self, id: &str, vault_id: &str, item_type: &str, blob: &[u8]) {
+            let now = chrono::Utc::now().to_rfc3339();
+            self.conn
+                .execute(
+                    "INSERT INTO encrypted_items \
+                     (id, vault_id, item_type, encrypted_blob, blob_version, created_at, updated_at) \
+                     VALUES (?1, ?2, ?3, ?4, 1, ?5, ?6)",
+                    params![id, vault_id, item_type, blob, now, now],
+                )
+                .unwrap();
+        }
+
+        pub fn load_item(&self, id: &str) -> Option<ItemRow> {
+            self.conn
+                .query_row(
+                    "SELECT id, encrypted_blob FROM encrypted_items WHERE id = ?1",
+                    params![id],
+                    |row| {
+                        Ok(ItemRow {
+                            id: row.get(0)?,
+                            encrypted_blob: row.get(1)?,
+                        })
+                    },
+                )
+                .ok()
+        }
+
+        pub fn list_items(&self, vault_id: &str, item_type: &str) -> Vec<ItemRow> {
+            let mut stmt = self
+                .conn
+                .prepare(
+                    "SELECT id, encrypted_blob FROM encrypted_items \
+                     WHERE vault_id = ?1 AND item_type = ?2 ORDER BY created_at",
+                )
+                .unwrap();
+            stmt.query_map(params![vault_id, item_type], |row| {
+                Ok(ItemRow {
+                    id: row.get(0)?,
+                    encrypted_blob: row.get(1)?,
+                })
+            })
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap()
+        }
+
+        pub fn update_item(&self, id: &str, blob: &[u8]) -> bool {
+            let now = chrono::Utc::now().to_rfc3339();
+            let updated = self
+                .conn
+                .execute(
+                    "UPDATE encrypted_items SET encrypted_blob = ?1, updated_at = ?2 WHERE id = ?3",
+                    params![blob, now, id],
+                )
+                .unwrap();
+            updated > 0
+        }
+
+        pub fn delete_item(&self, id: &str) -> bool {
+            let deleted = self
+                .conn
+                .execute("DELETE FROM encrypted_items WHERE id = ?1", params![id])
+                .unwrap();
+            deleted > 0
+        }
+
+        pub fn count_items(&self, vault_id: &str, item_type: &str) -> usize {
+            let count: i64 = self
+                .conn
+                .query_row(
+                    "SELECT COUNT(*) FROM encrypted_items WHERE vault_id = ?1 AND item_type = ?2",
+                    params![vault_id, item_type],
+                    |r| r.get(0),
+                )
+                .unwrap();
+            count as usize
+        }
+
+        pub fn create_vault(&self, id: &str) {
+            let now = chrono::Utc::now().to_rfc3339();
+            self.conn
+                .execute(
+                    "INSERT INTO vaults (id, encrypted_metadata, wrapped_vault_key, created_at, updated_at) \
+                     VALUES (?1, X'00', X'00', ?2, ?3)",
+                    params![id, now, now],
+                )
+                .unwrap();
+        }
+    }
+}
+
+use test_storage::Storage;
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+fn setup() -> (tempfile::TempDir, Storage, key_hierarchy::VaultKey, String) {
+    let tmp = tempfile::tempdir().unwrap();
+    let storage = Storage::open(tmp.path());
+    let vault_id = Uuid::new_v4().to_string();
+    storage.create_vault(&vault_id);
+    let vk = key_hierarchy::generate_vault_key();
+    (tmp, storage, vk, vault_id)
+}
+
+fn make_med(name: &str, dosage: &str, form: &str) -> Medication {
+    let now = Utc::now();
+    Medication {
+        id: Uuid::new_v4(),
+        name: name.to_string(),
+        generic_name: None,
+        brand_name: None,
+        dosage: dosage.to_string(),
+        form: form.to_string(),
+        prescriber: None,
+        pharmacy: None,
+        notes: None,
+        rxnorm_id: None,
+        start_date: None,
+        end_date: None,
+        created_at: now,
+        updated_at: now,
+    }
+}
+
+fn store_med(
+    storage: &Storage,
+    vk: &key_hierarchy::VaultKey,
+    vault_id: &str,
+    med: &Medication,
+) -> String {
+    let blob = encrypt_json(med, vk).unwrap();
+    let item_id = Uuid::new_v4().to_string();
+    storage.store_item(&item_id, vault_id, ITEM_TYPE, blob.to_bytes());
+    item_id
+}
+
+fn load_med(storage: &Storage, vk: &key_hierarchy::VaultKey, item_id: &str) -> Medication {
+    let row = storage.load_item(item_id).unwrap();
+    let blob = EncryptedBlob::from_bytes(row.encrypted_blob).unwrap();
+    decrypt_json(&blob, vk).unwrap()
+}
+
+fn list_meds(
+    storage: &Storage,
+    vk: &key_hierarchy::VaultKey,
+    vault_id: &str,
+) -> Vec<(String, Medication)> {
+    storage
+        .list_items(vault_id, ITEM_TYPE)
+        .into_iter()
+        .map(|row| {
+            let blob = EncryptedBlob::from_bytes(row.encrypted_blob).unwrap();
+            let med: Medication = decrypt_json(&blob, vk).unwrap();
+            (row.id, med)
+        })
+        .collect()
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn add_medication() {
+    let (_tmp, storage, vk, vault_id) = setup();
+
+    let med = make_med("Lisinopril", "10mg", "tablet");
+    let item_id = store_med(&storage, &vk, &vault_id, &med);
+
+    let loaded = load_med(&storage, &vk, &item_id);
+    assert_eq!(loaded.name, "Lisinopril");
+    assert_eq!(loaded.dosage, "10mg");
+    assert_eq!(loaded.form, "tablet");
+}
+
+#[test]
+fn list_medications() {
+    let (_tmp, storage, vk, vault_id) = setup();
+
+    store_med(
+        &storage,
+        &vk,
+        &vault_id,
+        &make_med("Lisinopril", "10mg", "tablet"),
+    );
+    store_med(
+        &storage,
+        &vk,
+        &vault_id,
+        &make_med("Vitamin D", "2000IU", "softgel"),
+    );
+    store_med(
+        &storage,
+        &vk,
+        &vault_id,
+        &make_med("Aspirin", "81mg", "tablet"),
+    );
+
+    let meds = list_meds(&storage, &vk, &vault_id);
+    assert_eq!(meds.len(), 3);
+}
+
+#[test]
+fn show_medication() {
+    let (_tmp, storage, vk, vault_id) = setup();
+
+    let mut med = make_med("Lisinopril", "10mg", "tablet");
+    med.prescriber = Some("Dr. Smith".to_string());
+    med.notes = Some("Take in morning".to_string());
+
+    let item_id = store_med(&storage, &vk, &vault_id, &med);
+
+    let loaded = load_med(&storage, &vk, &item_id);
+    assert_eq!(loaded.name, "Lisinopril");
+    assert_eq!(loaded.prescriber, Some("Dr. Smith".to_string()));
+    assert_eq!(loaded.notes, Some("Take in morning".to_string()));
+    assert_eq!(loaded.dosage, "10mg");
+    assert_eq!(loaded.form, "tablet");
+}
+
+#[test]
+fn edit_medication() {
+    let (_tmp, storage, vk, vault_id) = setup();
+
+    let med = make_med("Lisinopril", "10mg", "tablet");
+    let item_id = store_med(&storage, &vk, &vault_id, &med);
+
+    // Edit dosage
+    let mut loaded = load_med(&storage, &vk, &item_id);
+    loaded.dosage = "20mg".to_string();
+    loaded.updated_at = Utc::now();
+
+    let blob = encrypt_json(&loaded, &vk).unwrap();
+    assert!(storage.update_item(&item_id, blob.to_bytes()));
+
+    let updated = load_med(&storage, &vk, &item_id);
+    assert_eq!(updated.dosage, "20mg");
+    assert_eq!(updated.name, "Lisinopril");
+}
+
+#[test]
+fn delete_medication() {
+    let (_tmp, storage, vk, vault_id) = setup();
+
+    let med = make_med("Lisinopril", "10mg", "tablet");
+    let item_id = store_med(&storage, &vk, &vault_id, &med);
+
+    assert_eq!(storage.count_items(&vault_id, ITEM_TYPE), 1);
+    assert!(storage.delete_item(&item_id));
+    assert_eq!(storage.count_items(&vault_id, ITEM_TYPE), 0);
+}
+
+#[test]
+fn name_matching_substring() {
+    let (_tmp, storage, vk, vault_id) = setup();
+
+    store_med(
+        &storage,
+        &vk,
+        &vault_id,
+        &make_med("Lisinopril", "10mg", "tablet"),
+    );
+    store_med(
+        &storage,
+        &vk,
+        &vault_id,
+        &make_med("Aspirin", "81mg", "tablet"),
+    );
+    store_med(
+        &storage,
+        &vk,
+        &vault_id,
+        &make_med("Vitamin D", "2000IU", "softgel"),
+    );
+
+    let meds = list_meds(&storage, &vk, &vault_id);
+
+    // Substring match "lisin" should find "Lisinopril" (case-insensitive)
+    let query = "lisin";
+    let lower = query.to_lowercase();
+    let matches: Vec<_> = meds
+        .iter()
+        .filter(|(_id, m)| m.name.to_lowercase().contains(&lower))
+        .collect();
+    assert_eq!(matches.len(), 1);
+    assert_eq!(matches[0].1.name, "Lisinopril");
+
+    // "in" matches both "Lisinopril" and "Vitamin D" (contains "in")
+    let query2 = "in";
+    let lower2 = query2.to_lowercase();
+    let matches2: Vec<_> = meds
+        .iter()
+        .filter(|(_id, m)| m.name.to_lowercase().contains(&lower2))
+        .collect();
+    assert!(matches2.len() >= 2);
+}
+
+#[test]
+fn full_crud_cycle() {
+    let (_tmp, storage, vk, vault_id) = setup();
+
+    // Create
+    let med = make_med("Metformin", "500mg", "tablet");
+    let item_id = store_med(&storage, &vk, &vault_id, &med);
+    assert_eq!(storage.count_items(&vault_id, ITEM_TYPE), 1);
+
+    // Read (list)
+    let meds = list_meds(&storage, &vk, &vault_id);
+    assert_eq!(meds.len(), 1);
+    assert_eq!(meds[0].1.name, "Metformin");
+
+    // Read (show)
+    let loaded = load_med(&storage, &vk, &item_id);
+    assert_eq!(loaded.dosage, "500mg");
+
+    // Update
+    let mut edited = loaded;
+    edited.dosage = "1000mg".to_string();
+    edited.notes = Some("Take with food".to_string());
+    edited.updated_at = Utc::now();
+    let blob = encrypt_json(&edited, &vk).unwrap();
+    assert!(storage.update_item(&item_id, blob.to_bytes()));
+
+    let after_edit = load_med(&storage, &vk, &item_id);
+    assert_eq!(after_edit.dosage, "1000mg");
+    assert_eq!(after_edit.notes, Some("Take with food".to_string()));
+
+    // Delete
+    assert!(storage.delete_item(&item_id));
+    assert_eq!(storage.count_items(&vault_id, ITEM_TYPE), 0);
+}

--- a/cli/tests/schedule_test.rs
+++ b/cli/tests/schedule_test.rs
@@ -1,0 +1,426 @@
+use chrono::{NaiveDate, NaiveTime, Utc, Weekday};
+use serde::{Deserialize, Serialize};
+
+// ── Mirror types from the binary crate ──────────────────────────────────────
+// Integration tests cannot import from a binary crate, so we replicate the
+// schedule models needed for testing.
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct Schedule {
+    medication_id: String,
+    medication_name: String,
+    pattern: SchedulePattern,
+    times: Vec<NaiveTime>,
+    created_at: chrono::DateTime<Utc>,
+    updated_at: chrono::DateTime<Utc>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+enum SchedulePattern {
+    Daily,
+    EveryNDays {
+        interval: u32,
+        start_date: NaiveDate,
+    },
+    SpecificDays {
+        days: Vec<Weekday>,
+    },
+    Prn,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+enum DoseStatus {
+    Taken,
+    Skipped,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct DoseLog {
+    medication_id: String,
+    medication_name: String,
+    taken_at: chrono::DateTime<Utc>,
+    status: DoseStatus,
+    notes: Option<String>,
+    created_at: chrono::DateTime<Utc>,
+}
+
+// ── Minimal test storage ────────────────────────────────────────────────────
+
+mod test_storage {
+    use chrono::Utc;
+    use rusqlite::{Connection, params};
+    use std::fs;
+    use std::path::{Path, PathBuf};
+
+    #[derive(Debug)]
+    pub struct ItemRow {
+        pub id: String,
+        pub encrypted_blob: Vec<u8>,
+    }
+
+    pub struct Storage {
+        conn: Connection,
+        _data_dir: PathBuf,
+    }
+
+    impl Storage {
+        pub fn open(data_dir: &Path) -> Self {
+            fs::create_dir_all(data_dir).unwrap();
+            let db_path = data_dir.join("pildora.db");
+            let conn = Connection::open(&db_path).unwrap();
+
+            conn.pragma_update(None, "journal_mode", "WAL").unwrap();
+            conn.pragma_update(None, "foreign_keys", "ON").unwrap();
+            conn.execute_batch(
+                "CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL);
+                 CREATE TABLE IF NOT EXISTS account_state (
+                     id INTEGER PRIMARY KEY CHECK (id = 1),
+                     salt BLOB NOT NULL,
+                     argon2_memory_kib INTEGER NOT NULL DEFAULT 65536,
+                     argon2_iterations INTEGER NOT NULL DEFAULT 3,
+                     argon2_parallelism INTEGER NOT NULL DEFAULT 1,
+                     recovery_wrapped_mek BLOB,
+                     recovery_key_encrypted BLOB,
+                     created_at TEXT NOT NULL
+                 );
+                 CREATE TABLE IF NOT EXISTS vaults (
+                     id TEXT PRIMARY KEY,
+                     encrypted_metadata BLOB NOT NULL,
+                     wrapped_vault_key BLOB NOT NULL,
+                     created_at TEXT NOT NULL,
+                     updated_at TEXT NOT NULL
+                 );
+                 CREATE TABLE IF NOT EXISTS encrypted_items (
+                     id TEXT PRIMARY KEY,
+                     vault_id TEXT NOT NULL REFERENCES vaults(id) ON DELETE CASCADE,
+                     item_type TEXT NOT NULL,
+                     encrypted_blob BLOB NOT NULL,
+                     blob_version INTEGER NOT NULL DEFAULT 1,
+                     created_at TEXT NOT NULL,
+                     updated_at TEXT NOT NULL
+                 );",
+            )
+            .unwrap();
+
+            Self {
+                conn,
+                _data_dir: data_dir.to_path_buf(),
+            }
+        }
+
+        pub fn store_item(&self, id: &str, vault_id: &str, item_type: &str, blob: &[u8]) {
+            let now = Utc::now().to_rfc3339();
+            self.conn
+                .execute(
+                    "INSERT INTO encrypted_items \
+                     (id, vault_id, item_type, encrypted_blob, blob_version, created_at, updated_at) \
+                     VALUES (?1, ?2, ?3, ?4, 1, ?5, ?6)",
+                    params![id, vault_id, item_type, blob, now, now],
+                )
+                .unwrap();
+        }
+
+        pub fn list_items(&self, vault_id: &str, item_type: &str) -> Vec<ItemRow> {
+            let mut stmt = self
+                .conn
+                .prepare(
+                    "SELECT id, encrypted_blob FROM encrypted_items \
+                     WHERE vault_id = ?1 AND item_type = ?2 ORDER BY created_at",
+                )
+                .unwrap();
+            stmt.query_map(params![vault_id, item_type], |row| {
+                Ok(ItemRow {
+                    id: row.get(0)?,
+                    encrypted_blob: row.get(1)?,
+                })
+            })
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap()
+        }
+
+        pub fn create_vault(&self, id: &str) {
+            let now = Utc::now().to_rfc3339();
+            self.conn
+                .execute(
+                    "INSERT INTO vaults (id, encrypted_metadata, wrapped_vault_key, created_at, updated_at) \
+                     VALUES (?1, X'00', X'00', ?2, ?3)",
+                    params![id, now, now],
+                )
+                .unwrap();
+        }
+    }
+}
+
+use pildora_crypto::key_hierarchy;
+use pildora_crypto::vault::{EncryptedBlob, decrypt_json, encrypt_json};
+use test_storage::Storage;
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+fn setup() -> (tempfile::TempDir, Storage, key_hierarchy::VaultKey, String) {
+    let tmp = tempfile::tempdir().unwrap();
+    let storage = Storage::open(tmp.path());
+    let vault_id = uuid::Uuid::new_v4().to_string();
+    storage.create_vault(&vault_id);
+    let vk = key_hierarchy::generate_vault_key();
+    (tmp, storage, vk, vault_id)
+}
+
+fn store_item<T: serde::Serialize>(
+    storage: &Storage,
+    vk: &key_hierarchy::VaultKey,
+    vault_id: &str,
+    item_type: &str,
+    item: &T,
+) -> String {
+    let blob = encrypt_json(item, vk).unwrap();
+    let item_id = uuid::Uuid::new_v4().to_string();
+    storage.store_item(&item_id, vault_id, item_type, blob.to_bytes());
+    item_id
+}
+
+fn list_items<T: serde::de::DeserializeOwned>(
+    storage: &Storage,
+    vk: &key_hierarchy::VaultKey,
+    vault_id: &str,
+    item_type: &str,
+) -> Vec<(String, T)> {
+    storage
+        .list_items(vault_id, item_type)
+        .into_iter()
+        .map(|row| {
+            let blob = EncryptedBlob::from_bytes(row.encrypted_blob).unwrap();
+            let item: T = decrypt_json(&blob, vk).unwrap();
+            (row.id, item)
+        })
+        .collect()
+}
+
+fn make_schedule(
+    med_id: &str,
+    med_name: &str,
+    pattern: SchedulePattern,
+    times: Vec<NaiveTime>,
+) -> Schedule {
+    let now = Utc::now();
+    Schedule {
+        medication_id: med_id.to_string(),
+        medication_name: med_name.to_string(),
+        pattern,
+        times,
+        created_at: now,
+        updated_at: now,
+    }
+}
+
+fn make_dose_log(med_id: &str, med_name: &str, status: DoseStatus, notes: Option<&str>) -> DoseLog {
+    let now = Utc::now();
+    DoseLog {
+        medication_id: med_id.to_string(),
+        medication_name: med_name.to_string(),
+        taken_at: now,
+        status,
+        notes: notes.map(String::from),
+        created_at: now,
+    }
+}
+
+// ── Schedule serialization tests ────────────────────────────────────────────
+
+#[test]
+fn schedule_store_and_load_daily() {
+    let (_tmp, storage, vk, vault_id) = setup();
+
+    let schedule = make_schedule(
+        "med-1",
+        "Lisinopril",
+        SchedulePattern::Daily,
+        vec![
+            NaiveTime::from_hms_opt(8, 0, 0).unwrap(),
+            NaiveTime::from_hms_opt(20, 0, 0).unwrap(),
+        ],
+    );
+
+    store_item(&storage, &vk, &vault_id, "schedule", &schedule);
+
+    let loaded: Vec<(String, Schedule)> = list_items(&storage, &vk, &vault_id, "schedule");
+    assert_eq!(loaded.len(), 1);
+
+    let (_, s) = &loaded[0];
+    assert_eq!(s.medication_name, "Lisinopril");
+    assert_eq!(s.times.len(), 2);
+    assert!(matches!(s.pattern, SchedulePattern::Daily));
+}
+
+#[test]
+fn schedule_store_and_load_every_n_days() {
+    let (_tmp, storage, vk, vault_id) = setup();
+
+    let start = NaiveDate::from_ymd_opt(2026, 4, 25).unwrap();
+    let schedule = make_schedule(
+        "med-2",
+        "Metformin",
+        SchedulePattern::EveryNDays {
+            interval: 3,
+            start_date: start,
+        },
+        vec![NaiveTime::from_hms_opt(9, 0, 0).unwrap()],
+    );
+
+    store_item(&storage, &vk, &vault_id, "schedule", &schedule);
+
+    let loaded: Vec<(String, Schedule)> = list_items(&storage, &vk, &vault_id, "schedule");
+    assert_eq!(loaded.len(), 1);
+
+    let (_, s) = &loaded[0];
+    match &s.pattern {
+        SchedulePattern::EveryNDays {
+            interval,
+            start_date,
+        } => {
+            assert_eq!(*interval, 3);
+            assert_eq!(*start_date, start);
+        }
+        other => panic!("Expected EveryNDays, got {other:?}"),
+    }
+}
+
+#[test]
+fn schedule_store_and_load_specific_days() {
+    let (_tmp, storage, vk, vault_id) = setup();
+
+    let schedule = make_schedule(
+        "med-3",
+        "Vitamin D",
+        SchedulePattern::SpecificDays {
+            days: vec![Weekday::Mon, Weekday::Wed, Weekday::Fri],
+        },
+        vec![NaiveTime::from_hms_opt(8, 0, 0).unwrap()],
+    );
+
+    store_item(&storage, &vk, &vault_id, "schedule", &schedule);
+
+    let loaded: Vec<(String, Schedule)> = list_items(&storage, &vk, &vault_id, "schedule");
+    assert_eq!(loaded.len(), 1);
+
+    let (_, s) = &loaded[0];
+    match &s.pattern {
+        SchedulePattern::SpecificDays { days } => {
+            assert_eq!(days.len(), 3);
+            assert!(days.contains(&Weekday::Mon));
+            assert!(days.contains(&Weekday::Wed));
+            assert!(days.contains(&Weekday::Fri));
+        }
+        other => panic!("Expected SpecificDays, got {other:?}"),
+    }
+}
+
+#[test]
+fn schedule_store_and_load_prn() {
+    let (_tmp, storage, vk, vault_id) = setup();
+
+    let schedule = make_schedule("med-4", "Ibuprofen", SchedulePattern::Prn, vec![]);
+
+    store_item(&storage, &vk, &vault_id, "schedule", &schedule);
+
+    let loaded: Vec<(String, Schedule)> = list_items(&storage, &vk, &vault_id, "schedule");
+    assert_eq!(loaded.len(), 1);
+
+    let (_, s) = &loaded[0];
+    assert!(matches!(s.pattern, SchedulePattern::Prn));
+    assert!(s.times.is_empty());
+}
+
+// ── Dose log tests ──────────────────────────────────────────────────────────
+
+#[test]
+fn dose_log_store_taken() {
+    let (_tmp, storage, vk, vault_id) = setup();
+
+    let log = make_dose_log("med-1", "Lisinopril", DoseStatus::Taken, None);
+    store_item(&storage, &vk, &vault_id, "dose_log", &log);
+
+    let loaded: Vec<(String, DoseLog)> = list_items(&storage, &vk, &vault_id, "dose_log");
+    assert_eq!(loaded.len(), 1);
+    assert_eq!(loaded[0].1.status, DoseStatus::Taken);
+    assert_eq!(loaded[0].1.medication_name, "Lisinopril");
+    assert!(loaded[0].1.notes.is_none());
+}
+
+#[test]
+fn dose_log_store_skipped_with_reason() {
+    let (_tmp, storage, vk, vault_id) = setup();
+
+    let log = make_dose_log(
+        "med-1",
+        "Lisinopril",
+        DoseStatus::Skipped,
+        Some("out of stock"),
+    );
+    store_item(&storage, &vk, &vault_id, "dose_log", &log);
+
+    let loaded: Vec<(String, DoseLog)> = list_items(&storage, &vk, &vault_id, "dose_log");
+    assert_eq!(loaded.len(), 1);
+    assert_eq!(loaded[0].1.status, DoseStatus::Skipped);
+    assert_eq!(loaded[0].1.notes.as_deref(), Some("out of stock"));
+}
+
+#[test]
+fn dose_log_list_multiple() {
+    let (_tmp, storage, vk, vault_id) = setup();
+
+    store_item(
+        &storage,
+        &vk,
+        &vault_id,
+        "dose_log",
+        &make_dose_log("med-1", "Lisinopril", DoseStatus::Taken, None),
+    );
+    store_item(
+        &storage,
+        &vk,
+        &vault_id,
+        "dose_log",
+        &make_dose_log("med-2", "Metformin", DoseStatus::Taken, None),
+    );
+    store_item(
+        &storage,
+        &vk,
+        &vault_id,
+        "dose_log",
+        &make_dose_log("med-1", "Lisinopril", DoseStatus::Skipped, Some("forgot")),
+    );
+
+    let loaded: Vec<(String, DoseLog)> = list_items(&storage, &vk, &vault_id, "dose_log");
+    assert_eq!(loaded.len(), 3);
+}
+
+#[test]
+fn full_flow_schedule_and_dose() {
+    let (_tmp, storage, vk, vault_id) = setup();
+
+    // Store a schedule
+    let schedule = make_schedule(
+        "med-1",
+        "Lisinopril",
+        SchedulePattern::Daily,
+        vec![
+            NaiveTime::from_hms_opt(8, 0, 0).unwrap(),
+            NaiveTime::from_hms_opt(20, 0, 0).unwrap(),
+        ],
+    );
+    store_item(&storage, &vk, &vault_id, "schedule", &schedule);
+
+    // Log a dose
+    let dose = make_dose_log("med-1", "Lisinopril", DoseStatus::Taken, None);
+    store_item(&storage, &vk, &vault_id, "dose_log", &dose);
+
+    // Verify both exist
+    let schedules: Vec<(String, Schedule)> = list_items(&storage, &vk, &vault_id, "schedule");
+    assert_eq!(schedules.len(), 1);
+
+    let logs: Vec<(String, DoseLog)> = list_items(&storage, &vk, &vault_id, "dose_log");
+    assert_eq!(logs.len(), 1);
+    assert_eq!(logs[0].1.medication_id, schedules[0].1.medication_id);
+}


### PR DESCRIPTION
## Description

Implement medication CRUD and the schedule/dose tracking loop for the CLI.

### What's included

- **Medication CRUD** — `pildora med add` creates medications with flags (`--dosage`, `--form`, `--generic`, `--brand`, `--prescriber`, `--pharmacy`, `--notes`). `med list` displays a table of all medications. `med show` finds medications by case-insensitive name substring and displays full details. `med edit` updates individual fields. `med delete` prompts for confirmation (or `--force` to skip). Expanded data model with 14 fields including prescriber, pharmacy, start/end dates, and RxNorm ID.
- **Schedule engine** — Pure computation module supporting four schedule patterns: daily (with multiple times), every N days (with anchor date), specific weekdays, and PRN (as needed). Computes upcoming doses and determines which dates match a pattern. Handles edge cases like sorted/deduped times and spring-forward skipping.
- **Schedule commands** — `pildora schedule set <med>` with `--pattern`, `--times`, `--interval`, `--days`, and `--start-date` flags. `schedule show` displays the schedule and next upcoming doses in a table. Supports update-or-create semantics.
- **Dose logging** — `pildora dose log <med>` records a taken dose (with optional `--at HH:MM` time). `dose skip <med>` records a skipped dose with reason. `dose today` cross-references schedules with logs to show each dose as taken, missed, upcoming, or skipped. `dose history` shows logs grouped by date.
- **Shared unlock context** — Extracted `UnlockedContext::require()` and `find_medication()` helpers for DRY access to the unlocked vault across all data commands.

## Related Issues

Closes #16, closes #17

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Component

- [x] `cli/` — CLI tool

## Privacy Checklist

- [x] No plaintext user health data is sent to or stored on the server
- [x] No new metadata exposure introduced (or documented if unavoidable)
- [x] Drug/health features include appropriate disclaimers and source attribution
- [x] Any new external service interaction is documented in the trust boundary model

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] Tests pass (if applicable)
- [x] I have updated documentation (if applicable)
