### PR TITLE
ci: group Dependabot updates into a single PR per ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,7 @@ updates:
       - "ci"
       - "dependencies"
     open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Description

Enables grouped Dependabot pull requests so version bumps are bundled into one PR per ecosystem instead of one PR per dependency. This reduces PR noise and review/CI overhead.

The config currently has a single `github-actions` ecosystem block. Added a `groups:` block to it that bundles all dependencies (`patterns: ["*"]`) under a `github-actions` group key. All existing keys were preserved exactly.

## Related Issues

N/A

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [x] CI / infrastructure
- [ ] Other (describe below)

## Component

- [ ] `crypto/` — Encryption library
- [ ] `ios/` — Apple platform apps
- [ ] `web/` — Web app
- [ ] `cli/` — CLI tool
- [ ] `server/` — Sync server
- [ ] `data/` — Drug data pipeline
- [ ] `docs/` — Documentation

This touches `.github/dependabot.yml` only (CI infrastructure).

## Privacy Checklist

- [x] No plaintext user health data is sent to or stored on the server
- [x] No new metadata exposure introduced (or documented if unavoidable)
- [x] Drug/health features include appropriate disclaimers and source attribution
- [x] Any new external service interaction is documented in the trust boundary model

N/A — config-only change with no runtime or data-path impact.

## Checklist

- [ ] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] Tests pass (if applicable)
- [ ] I have updated documentation (if applicable)