### PR TITLE
feat: iOS medication list with search, inventory tracking, and export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- iOS medication list feature (`ios/medication-list/`): SwiftUI package with a searchable, category-grouped medication list, drug reference display (class, side effects, source + date attribution, informational-only disclaimer), manual inventory tracking with user-configurable low-stock thresholds and local refill reminders, a profile/settings screen, and on-device data export (decrypted JSON + Doctor Mode PDF). Self-contained against an in-memory sample store pending the data layer (#44), CRUD (#48), and design system (#43).
 - `pildora-crypto-ffi` crate: UniFFI bindings exposing `pildora-crypto` to Swift via FFI (ADR-007)
 - iOS FFI spike: prototype Swift app validating Rust → Swift FFI bridge with encrypt/decrypt roundtrip and benchmarks
 - iOS SQLCipher spike: GRDB.swift integration with encrypted storage, 4-table data model, CRUD benchmarks, and vault-per-database architecture

--- a/ios/README.md
+++ b/ios/README.md
@@ -38,11 +38,14 @@ core crypto crate to preserve the `unsafe_code = "deny"` invariant.
 
 ## Status
 
-🚧 Not yet implemented. Four technical spikes have been validated:
+🚧 Not yet implemented as a shipping app. Four technical spikes have been
+validated, and the first Phase 1 feature slice has been built as a
+standalone SwiftUI package:
 
 - **FFI bridge** ([`ffi-spike/`](ffi-spike/), issue #21) — Rust→Swift via UniFFI
 - **SQLCipher storage** ([`sqlcipher-spike/`](sqlcipher-spike/), issue #22) — GRDB.swift + encrypted SQLite
 - **Notification rotation** ([`notification-spike/`](notification-spike/), issue #23) — 64-limit rotation strategy with priority-based scheduling
 - **Accessibility baseline** ([`accessibility-spike/`](accessibility-spike/), issue #24) — SwiftUI + VoiceOver + Dynamic Type prototype
+- **Medication list + inventory** ([`medication-list/`](medication-list/PildoraMedicationList/), issue #50) — medication list with search, drug reference display, manual inventory tracking with low-stock / refill reminders, and profile + JSON/PDF export. Self-contained against an in-memory sample store until the data layer (#44), CRUD (#48), and design system (#43) land.
 
 Requires completion of `pildora-crypto` (Phase 0) before app development begins.

--- a/ios/medication-list/PildoraMedicationList/Package.swift
+++ b/ios/medication-list/PildoraMedicationList/Package.swift
@@ -1,0 +1,27 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "PildoraMedicationList",
+    platforms: [
+        .macOS(.v14),
+        .iOS(.v17),
+    ],
+    products: [
+        .library(
+            name: "PildoraMedicationList",
+            targets: ["PildoraMedicationList"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "PildoraMedicationList",
+            path: "Sources/PildoraMedicationList"
+        ),
+        .testTarget(
+            name: "PildoraMedicationListTests",
+            dependencies: ["PildoraMedicationList"],
+            path: "Tests/PildoraMedicationListTests"
+        ),
+    ]
+)

--- a/ios/medication-list/PildoraMedicationList/README.md
+++ b/ios/medication-list/PildoraMedicationList/README.md
@@ -1,0 +1,55 @@
+# PildoraMedicationList
+
+SwiftUI feature package for **issue #50** — the Phase 1 (S13) medication
+management surface: medication list with search, basic drug reference data
+display, manual inventory tracking with low-stock / refill alerts, and a
+profile screen with JSON + PDF (Doctor Mode) data export.
+
+## Status
+
+🚧 Self-contained feature slice. Because its dependencies are still open
+(#43 design system, #44 SQLCipher data layer, #48 CRUD), this package ships
+against an **in-memory sample store** and a **minimal local design-token
+subset** so the screens are buildable, previewable, and testable today. The
+store and notification scheduler are protocol-/`ObservableObject`-backed so
+the real persistence and design system can be swapped in later.
+
+## Build & test
+
+```sh
+cd ios/medication-list/PildoraMedicationList
+swift build
+swift test
+```
+
+Builds on the macOS toolchain (same bar as the `ios/` spikes). iOS-only APIs
+(`UNUserNotificationCenter`, `UIGraphicsPDFRenderer`) are guarded with
+`#if os(iOS)` / `#if canImport(UIKit)` and backed by a simulated
+implementation on macOS.
+
+## Wiring points (for later issues)
+
+| Concern | Today (this package) | Swap-in |
+|---|---|---|
+| Persistence | `MedicationStore` in-memory sample data | GRDB + SQLCipher data layer (#44) |
+| CRUD | `MedicationStore` mutators (inventory, settings) | Full CRUD + autocomplete (#48) |
+| Design tokens | `DesignSystem/` minimal subset | Full design system (#43) |
+| Drug reference | `SampleData` reference entries | Local FTS5 drug index (ETL output) |
+
+## Privacy / compliance notes
+
+- **Zero-knowledge / local-first:** all user data stays on-device. JSON and
+  PDF export are generated entirely on-device — no server involvement.
+- **Local notifications only:** refill reminders use local notifications so
+  the server never learns dose/refill timing.
+- **Disclaimers:** every drug reference datum displays its **source + date**,
+  and reference sections carry the informational-only disclaimer
+  ("This is informational only. Consult your healthcare provider.").
+
+## Scope notes
+
+- Inventory here is **manual** (user edits the count) per the issue's
+  acceptance criteria. Automatic decrement on dose confirmation belongs with
+  dose logging and is out of scope.
+- Models carry a `vaultId` (one vault = one encryption boundary) per repo
+  convention, even though the UI currently shows a single active vault.

--- a/ios/medication-list/PildoraMedicationList/Sources/PildoraMedicationList/DesignSystem/Components.swift
+++ b/ios/medication-list/PildoraMedicationList/Sources/PildoraMedicationList/DesignSystem/Components.swift
@@ -1,0 +1,138 @@
+import SwiftUI
+
+// MARK: - Base Components (minimal design-system subset)
+
+/// A rounded surface container used to group related content.
+public struct Card<Content: View>: View {
+    private let content: Content
+
+    public init(@ViewBuilder content: () -> Content) {
+        self.content = content()
+    }
+
+    public var body: some View {
+        content
+            .padding(Theme.Spacing.lg)
+            .background(Theme.Colors.surface)
+            .clipShape(RoundedRectangle(cornerRadius: Theme.Radius.md, style: .continuous))
+    }
+}
+
+// MARK: - Status Badge
+
+/// Severity levels for a `StatusBadge`. Each carries text *and* an icon, so
+/// status is never communicated by color alone (accessibility requirement).
+public enum StatusLevel: Sendable {
+    case neutral
+    case info
+    case success
+    case warning
+    case error
+
+    var color: Color {
+        switch self {
+        case .neutral: return Theme.Colors.textSecondary
+        case .info: return Theme.Colors.info
+        case .success: return Theme.Colors.success
+        case .warning: return Theme.Colors.warning
+        case .error: return Theme.Colors.error
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .neutral: return "circle"
+        case .info: return "info.circle.fill"
+        case .success: return "checkmark.circle.fill"
+        case .warning: return "exclamationmark.triangle.fill"
+        case .error: return "exclamationmark.octagon.fill"
+        }
+    }
+}
+
+/// A compact labeled status indicator. Text + icon + color, never color alone.
+public struct StatusBadge: View {
+    private let text: String
+    private let level: StatusLevel
+
+    public init(_ text: String, level: StatusLevel) {
+        self.text = text
+        self.level = level
+    }
+
+    public var body: some View {
+        HStack(spacing: Theme.Spacing.xs) {
+            Image(systemName: level.systemImage)
+                .imageScale(.small)
+                .accessibilityHidden(true)
+            Text(text)
+                .font(Typography.caption.weight(.medium))
+        }
+        .foregroundStyle(level.color)
+        .accessibilityElement(children: .combine)
+    }
+}
+
+// MARK: - List Row
+
+/// A leading-icon / title / trailing-detail row used in lists.
+public struct ListRow<Trailing: View>: View {
+    private let systemImage: String?
+    private let title: String
+    private let subtitle: String?
+    private let trailing: Trailing
+
+    public init(
+        systemImage: String? = nil,
+        title: String,
+        subtitle: String? = nil,
+        @ViewBuilder trailing: () -> Trailing = { EmptyView() }
+    ) {
+        self.systemImage = systemImage
+        self.title = title
+        self.subtitle = subtitle
+        self.trailing = trailing()
+    }
+
+    public var body: some View {
+        HStack(spacing: Theme.Spacing.md) {
+            if let systemImage {
+                Image(systemName: systemImage)
+                    .foregroundStyle(Theme.Colors.primary)
+                    .accessibilityHidden(true)
+            }
+            VStack(alignment: .leading, spacing: Theme.Spacing.xxs) {
+                Text(title)
+                    .font(Typography.body)
+                    .foregroundStyle(Theme.Colors.textPrimary)
+                if let subtitle {
+                    Text(subtitle)
+                        .font(Typography.caption)
+                        .foregroundStyle(Theme.Colors.textSecondary)
+                }
+            }
+            Spacer(minLength: Theme.Spacing.sm)
+            trailing
+        }
+        .frame(minHeight: 44)
+    }
+}
+
+// MARK: - Source Tag
+
+/// Renders a drug-reference attribution line ("Source: openFDA · Jan 12, 2026").
+/// Required on every piece of displayed drug reference data.
+public struct SourceTag: View {
+    private let text: String
+
+    public init(_ text: String) {
+        self.text = text
+    }
+
+    public var body: some View {
+        Text(text)
+            .font(Typography.caption)
+            .foregroundStyle(Theme.Colors.textSecondary)
+            .accessibilityLabel(text)
+    }
+}

--- a/ios/medication-list/PildoraMedicationList/Sources/PildoraMedicationList/DesignSystem/PlatformStyle.swift
+++ b/ios/medication-list/PildoraMedicationList/Sources/PildoraMedicationList/DesignSystem/PlatformStyle.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+// MARK: - Cross-platform list styling
+
+extension View {
+    /// Applies the inset-grouped list style on iOS, falling back to a sensible
+    /// default on platforms (macOS) where it is unavailable, so the package
+    /// builds and previews everywhere.
+    @ViewBuilder
+    func groupedListStyle() -> some View {
+        #if os(iOS)
+        self.listStyle(.insetGrouped)
+        #else
+        self.listStyle(.sidebar)
+        #endif
+    }
+}

--- a/ios/medication-list/PildoraMedicationList/Sources/PildoraMedicationList/DesignSystem/Theme.swift
+++ b/ios/medication-list/PildoraMedicationList/Sources/PildoraMedicationList/DesignSystem/Theme.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+
+// MARK: - Theme (minimal design-token subset)
+
+/// Minimal local subset of the full design system (#43). Provides semantic
+/// color and spacing tokens so this feature is visually consistent and
+/// dark-mode aware today, and can be replaced by the real design system later
+/// without touching call sites that use `Theme`.
+public enum Theme {
+
+    // MARK: Spacing — 4pt / 8pt grid
+
+    public enum Spacing {
+        public static let xxs: CGFloat = 2
+        public static let xs: CGFloat = 4
+        public static let sm: CGFloat = 8
+        public static let md: CGFloat = 12
+        public static let lg: CGFloat = 16
+        public static let xl: CGFloat = 24
+        public static let xxl: CGFloat = 32
+    }
+
+    public enum Radius {
+        public static let sm: CGFloat = 8
+        public static let md: CGFloat = 12
+        public static let lg: CGFloat = 16
+    }
+
+    // MARK: Semantic colors
+    //
+    // Uses system semantic colors so light/dark mode and high-contrast
+    // accessibility settings are honored automatically.
+
+    public enum Colors {
+        public static let primary = Color.accentColor
+        public static let surface = Color(uiColorName: .secondarySystemBackground)
+        public static let surfaceElevated = Color(uiColorName: .tertiarySystemBackground)
+        public static let textPrimary = Color.primary
+        public static let textSecondary = Color.secondary
+        public static let success = Color.green
+        public static let warning = Color.orange
+        public static let error = Color.red
+        public static let info = Color.blue
+    }
+}
+
+// MARK: - Cross-platform semantic background colors
+
+/// Names for platform-semantic background colors that exist on UIKit but not
+/// on macOS AppKit. Mapped to sensible equivalents so the package builds and
+/// previews on both platforms.
+enum SemanticColorName {
+    case secondarySystemBackground
+    case tertiarySystemBackground
+}
+
+extension Color {
+    init(uiColorName name: SemanticColorName) {
+        #if canImport(UIKit)
+        switch name {
+        case .secondarySystemBackground:
+            self = Color(uiColor: .secondarySystemBackground)
+        case .tertiarySystemBackground:
+            self = Color(uiColor: .tertiarySystemBackground)
+        }
+        #else
+        // macOS fallback approximations for previews / `swift build`.
+        switch name {
+        case .secondarySystemBackground:
+            self = Color.gray.opacity(0.12)
+        case .tertiarySystemBackground:
+            self = Color.gray.opacity(0.06)
+        }
+        #endif
+    }
+}

--- a/ios/medication-list/PildoraMedicationList/Sources/PildoraMedicationList/DesignSystem/Typography.swift
+++ b/ios/medication-list/PildoraMedicationList/Sources/PildoraMedicationList/DesignSystem/Typography.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+// MARK: - Typography
+
+/// Dynamic Type helpers. All text uses semantic `Font.TextStyle`s so it scales
+/// with the user's preferred content size up to the accessibility (xxxLarge+)
+/// sizes required by the project's accessibility persona.
+public enum Typography {
+    public static let cardTitle: Font = .headline
+    public static let cardSubtitle: Font = .subheadline
+    public static let body: Font = .body
+    public static let caption: Font = .footnote
+    public static let sectionHeader: Font = .title3.weight(.semibold)
+}
+
+public extension View {
+    /// Marks a view as a heading for VoiceOver and applies the section header font.
+    func sectionHeaderStyle() -> some View {
+        self
+            .font(Typography.sectionHeader)
+            .accessibilityAddTraits(.isHeader)
+    }
+}

--- a/ios/medication-list/PildoraMedicationList/Sources/PildoraMedicationList/Export/DataExporter.swift
+++ b/ios/medication-list/PildoraMedicationList/Sources/PildoraMedicationList/Export/DataExporter.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+// MARK: - Export Models
+
+/// Codable snapshot of all user data for a full decrypted JSON export.
+///
+/// This is the user's own data, exported on-device at their request. It is
+/// **decrypted** by design (the export is for the user / their doctor) but is
+/// never transmitted to a server by this package.
+public struct ExportDocument: Codable, Equatable {
+    public struct Meta: Codable, Equatable {
+        public var app: String
+        public var schemaVersion: Int
+        public var exportedAt: Date
+        public var vaultId: String
+        public var disclaimer: String
+    }
+
+    public struct Entry: Codable, Equatable {
+        public var medication: Medication
+        public var inventory: InventoryRecord?
+        public var reference: DrugReference?
+    }
+
+    public var meta: Meta
+    public var medications: [Entry]
+}
+
+// MARK: - Data Exporter
+
+/// Produces a full decrypted JSON export of the user's medication data.
+public enum DataExporter {
+
+    public static let schemaVersion = 1
+
+    /// Build an `ExportDocument` from current store state.
+    @MainActor
+    public static func document(from store: MedicationStore, now: Date = Date()) -> ExportDocument {
+        let entries = store.medications
+            .sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+            .map { med in
+                ExportDocument.Entry(
+                    medication: med,
+                    inventory: store.inventory(for: med.id),
+                    reference: store.reference(for: med)
+                )
+            }
+        let vaultId = store.medications.first?.vaultId ?? "vault-default"
+        return ExportDocument(
+            meta: .init(
+                app: "Pildora",
+                schemaVersion: schemaVersion,
+                exportedAt: now,
+                vaultId: vaultId,
+                disclaimer: DrugReference.disclaimer
+            ),
+            medications: entries
+        )
+    }
+
+    /// Encode an export document to pretty-printed, sorted JSON data.
+    public static func jsonData(for document: ExportDocument) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        encoder.dateEncodingStrategy = .iso8601
+        return try encoder.encode(document)
+    }
+
+    /// Convenience: JSON `String` for an export document.
+    public static func jsonString(for document: ExportDocument) throws -> String {
+        let data = try jsonData(for: document)
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    /// Suggested filename for a JSON export, e.g. `pildora-export-2026-06-26.json`.
+    public static func suggestedFilename(now: Date = Date(), ext: String) -> String {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd"
+        return "pildora-export-\(f.string(from: now)).\(ext)"
+    }
+}

--- a/ios/medication-list/PildoraMedicationList/Sources/PildoraMedicationList/Export/PDFReportRenderer.swift
+++ b/ios/medication-list/PildoraMedicationList/Sources/PildoraMedicationList/Export/PDFReportRenderer.swift
@@ -1,0 +1,141 @@
+import Foundation
+
+// MARK: - PDF Report Content
+
+/// Platform-independent description of the Doctor Mode report. Building the
+/// content is separated from rendering so it can be unit-tested on any platform
+/// and rendered to PDF only where UIKit is available.
+public struct DoctorReport: Equatable {
+    public struct Line: Equatable {
+        public enum Style: Equatable { case title, heading, body, caption }
+        public var text: String
+        public var style: Style
+        public init(_ text: String, _ style: Style) {
+            self.text = text
+            self.style = style
+        }
+    }
+
+    public var lines: [Line]
+
+    /// Build the report from current store state.
+    @MainActor
+    public static func build(from store: MedicationStore, now: Date = Date()) -> DoctorReport {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateStyle = .long
+        dateFormatter.timeStyle = .short
+
+        var lines: [Line] = []
+        lines.append(.init("Pildora — Medication Summary", .title))
+        lines.append(.init("Generated \(dateFormatter.string(from: now))", .caption))
+        lines.append(.init(DrugReference.disclaimer, .caption))
+
+        // Always report the full medication set, independent of any active search filter.
+        for section in MedicationStore.group(store.medications) {
+            guard !section.medications.isEmpty else { continue }
+            lines.append(.init(section.category.displayName, .heading))
+            for med in section.medications {
+                lines.append(.init(med.titleWithDosage, .body))
+                var detail = "\(med.form.displayName) · \(med.frequency)"
+                if let prescriber = med.prescriber {
+                    detail += " · \(prescriber)"
+                }
+                lines.append(.init(detail, .caption))
+                if let inv = store.inventory(for: med.id) {
+                    lines.append(.init("Inventory: \(inv.currentCount) remaining (refill at \(inv.refillThreshold))", .caption))
+                }
+                if let ref = store.reference(for: med) {
+                    lines.append(.init("Class: \(ref.drugClass)", .caption))
+                    lines.append(.init(ref.attribution(), .caption))
+                }
+            }
+        }
+        return DoctorReport(lines: lines)
+    }
+
+    /// A plain-text rendering, used as a fallback (and for tests) when PDF
+    /// rendering is unavailable.
+    public var plainText: String {
+        lines.map { line in
+            switch line.style {
+            case .title: return line.text.uppercased()
+            case .heading: return "\n\(line.text)\n" + String(repeating: "-", count: line.text.count)
+            case .body: return line.text
+            case .caption: return "  \(line.text)"
+            }
+        }.joined(separator: "\n")
+    }
+}
+
+// MARK: - PDF Renderer
+
+/// Renders a `DoctorReport` to PDF **entirely on-device** (Doctor Mode).
+public enum PDFReportRenderer {
+
+    /// Render the report to PDF data. On platforms without UIKit (e.g. the
+    /// macOS toolchain build), returns a UTF-8 plain-text fallback so the API
+    /// is always available; callers should treat the bytes opaquely.
+    public static func render(_ report: DoctorReport) -> Data {
+        #if canImport(UIKit)
+        return renderPDF(report)
+        #else
+        return Data(report.plainText.utf8)
+        #endif
+    }
+}
+
+#if canImport(UIKit)
+import UIKit
+
+extension PDFReportRenderer {
+    private static func renderPDF(_ report: DoctorReport) -> Data {
+        // US Letter at 72 dpi.
+        let pageRect = CGRect(x: 0, y: 0, width: 612, height: 792)
+        let margin: CGFloat = 48
+        let contentWidth = pageRect.width - margin * 2
+        let renderer = UIGraphicsPDFRenderer(bounds: pageRect)
+
+        return renderer.pdfData { context in
+            context.beginPage()
+            var y: CGFloat = margin
+
+            for line in report.lines {
+                let attributes = attributes(for: line.style)
+                let bounding = (line.text as NSString).boundingRect(
+                    with: CGSize(width: contentWidth, height: .greatestFiniteMagnitude),
+                    options: [.usesLineFragmentOrigin, .usesFontLeading],
+                    attributes: attributes,
+                    context: nil
+                )
+                let spacingBefore: CGFloat = line.style == .heading ? 12 : 2
+                if y + bounding.height + spacingBefore > pageRect.height - margin {
+                    context.beginPage()
+                    y = margin
+                }
+                y += spacingBefore
+                (line.text as NSString).draw(
+                    in: CGRect(x: margin, y: y, width: contentWidth, height: bounding.height),
+                    withAttributes: attributes
+                )
+                y += bounding.height
+            }
+        }
+    }
+
+    private static func attributes(for style: DoctorReport.Line.Style) -> [NSAttributedString.Key: Any] {
+        switch style {
+        case .title:
+            return [.font: UIFont.boldSystemFont(ofSize: 22)]
+        case .heading:
+            return [.font: UIFont.boldSystemFont(ofSize: 15)]
+        case .body:
+            return [.font: UIFont.systemFont(ofSize: 12, weight: .medium)]
+        case .caption:
+            return [
+                .font: UIFont.systemFont(ofSize: 10),
+                .foregroundColor: UIColor.darkGray,
+            ]
+        }
+    }
+}
+#endif

--- a/ios/medication-list/PildoraMedicationList/Sources/PildoraMedicationList/Models/AppSettings.swift
+++ b/ios/medication-list/PildoraMedicationList/Sources/PildoraMedicationList/Models/AppSettings.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+// MARK: - App Settings
+
+/// User-configurable app settings surfaced on the profile screen.
+public struct AppSettings: Codable, Hashable, Sendable {
+    /// Default low-stock threshold applied to new medications.
+    public var defaultRefillThreshold: Int
+    /// Whether refill reminder notifications are enabled app-wide.
+    public var refillRemindersEnabled: Bool
+    /// Preferred appearance. `nil` follows the system setting.
+    public var preferredAppearance: Appearance
+
+    public enum Appearance: String, Codable, CaseIterable, Sendable {
+        case system
+        case light
+        case dark
+
+        public var displayName: String { rawValue.capitalized }
+    }
+
+    public init(
+        defaultRefillThreshold: Int = 7,
+        refillRemindersEnabled: Bool = true,
+        preferredAppearance: Appearance = .system
+    ) {
+        self.defaultRefillThreshold = defaultRefillThreshold
+        self.refillRemindersEnabled = refillRemindersEnabled
+        self.preferredAppearance = preferredAppearance
+    }
+
+    public static let `default` = AppSettings()
+}

--- a/ios/medication-list/PildoraMedicationList/Sources/PildoraMedicationList/Models/DrugReference.swift
+++ b/ios/medication-list/PildoraMedicationList/Sources/PildoraMedicationList/Models/DrugReference.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+// MARK: - Drug Reference
+
+/// Public, plaintext drug reference data shown alongside a medication.
+///
+/// This is **published reference data** (e.g. from openFDA / RxNorm via the
+/// local ETL index), not user health data — it is not encrypted. Per the
+/// project's disclaimer rules, every reference datum must display its
+/// `source` and `sourceDate`, and reference UI must carry the
+/// informational-only disclaimer.
+///
+/// Risk classification: 🟡 Informational — displays published reference data
+/// with source attribution. It must never present dosing recommendations or
+/// diagnostic suggestions.
+public struct DrugReference: Identifiable, Codable, Hashable, Sendable {
+    public var id: String
+    /// Therapeutic / pharmacologic class, e.g. "Biguanide (antidiabetic)".
+    public var drugClass: String
+    /// Commonly reported side effects (informational, not exhaustive).
+    public var commonSideEffects: [String]
+    /// Attribution: where this datum came from, e.g. "openFDA" or "RxNorm".
+    public var source: String
+    /// The date the source data was published / last refreshed.
+    public var sourceDate: Date
+
+    public init(
+        id: String = UUID().uuidString,
+        drugClass: String,
+        commonSideEffects: [String],
+        source: String,
+        sourceDate: Date
+    ) {
+        self.id = id
+        self.drugClass = drugClass
+        self.commonSideEffects = commonSideEffects
+        self.source = source
+        self.sourceDate = sourceDate
+    }
+
+    /// The standard informational-only disclaimer required on all reference data.
+    public static let disclaimer =
+        "This is informational only. Consult your healthcare provider."
+
+    /// "Source: openFDA · Jan 12, 2026" — attribution line for display.
+    public func attribution(formatter: DateFormatter = DrugReference.attributionDateFormatter) -> String {
+        "Source: \(source) · \(formatter.string(from: sourceDate))"
+    }
+
+    public static let attributionDateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateStyle = .medium
+        f.timeStyle = .none
+        return f
+    }()
+}

--- a/ios/medication-list/PildoraMedicationList/Sources/PildoraMedicationList/Models/InventoryRecord.swift
+++ b/ios/medication-list/PildoraMedicationList/Sources/PildoraMedicationList/Models/InventoryRecord.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+// MARK: - Inventory Record
+
+/// Manual inventory state for a medication: how many units remain, and the
+/// user-configurable threshold at or below which a low-stock / refill alert
+/// fires.
+///
+/// Inventory is **manual** in this feature (issue #50): the user edits the
+/// count. Automatic decrement on dose confirmation belongs with dose logging
+/// and is intentionally out of scope here.
+public struct InventoryRecord: Identifiable, Codable, Hashable, Sendable {
+    public var id: String
+    public var medicationId: String
+    /// Units (pills, mL, patches…) remaining.
+    public var currentCount: Int
+    /// Alert fires when `currentCount <= refillThreshold`. User-configurable.
+    public var refillThreshold: Int
+    /// Whether a refill reminder notification should be scheduled for this med.
+    public var refillReminderEnabled: Bool
+    public var lastRefillDate: Date?
+    public var updatedAt: Date
+
+    public init(
+        id: String = UUID().uuidString,
+        medicationId: String,
+        currentCount: Int,
+        refillThreshold: Int,
+        refillReminderEnabled: Bool = true,
+        lastRefillDate: Date? = nil,
+        updatedAt: Date = Date()
+    ) {
+        self.id = id
+        self.medicationId = medicationId
+        self.currentCount = currentCount
+        self.refillThreshold = refillThreshold
+        self.refillReminderEnabled = refillReminderEnabled
+        self.lastRefillDate = lastRefillDate
+        self.updatedAt = updatedAt
+    }
+
+    /// True when stock is at or below the user's threshold.
+    public var isLow: Bool { currentCount <= refillThreshold }
+
+    /// True when stock is critically low (at or below half the threshold,
+    /// or 3 units, whichever is larger) — used for stronger visual emphasis.
+    public var isCritical: Bool {
+        currentCount <= max(3, refillThreshold / 2)
+    }
+}

--- a/ios/medication-list/PildoraMedicationList/Sources/PildoraMedicationList/Models/Medication.swift
+++ b/ios/medication-list/PildoraMedicationList/Sources/PildoraMedicationList/Models/Medication.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+// MARK: - Medication Form
+
+/// The physical form a medication or supplement takes.
+public enum MedicationForm: String, Codable, CaseIterable, Sendable {
+    case tablet
+    case capsule
+    case liquid
+    case injection
+    case patch
+    case drops
+    case gummy
+    case powder
+
+    /// Singular noun used when describing inventory units (e.g. "tablet").
+    public var unitNoun: String {
+        switch self {
+        case .tablet: return "tablet"
+        case .capsule: return "capsule"
+        case .liquid: return "mL"
+        case .injection: return "dose"
+        case .patch: return "patch"
+        case .drops: return "drop"
+        case .gummy: return "gummy"
+        case .powder: return "scoop"
+        }
+    }
+
+    public var displayName: String { rawValue.capitalized }
+}
+
+// MARK: - Medication Category
+
+/// Grouping bucket used to organize the medication list.
+public enum MedicationCategory: String, Codable, CaseIterable, Sendable {
+    case prescription
+    case overTheCounter
+    case supplement
+    case vitamin
+
+    public var displayName: String {
+        switch self {
+        case .prescription: return "Prescription"
+        case .overTheCounter: return "Over-the-Counter"
+        case .supplement: return "Supplement"
+        case .vitamin: return "Vitamin"
+        }
+    }
+
+    /// Stable ordering for grouped section display.
+    public var sortOrder: Int {
+        switch self {
+        case .prescription: return 0
+        case .overTheCounter: return 1
+        case .supplement: return 2
+        case .vitamin: return 3
+        }
+    }
+}
+
+// MARK: - Medication
+
+/// A medication or supplement the user tracks.
+///
+/// Mirrors the field shape validated in the SQLCipher spike's `Medication`
+/// record (`id`, `vaultId`, `name`, `genericName`, `dosage`, `form`,
+/// `frequency`, `prescriber`, `notes`, `rxnormId`) so it can be mapped onto
+/// the real persistence layer (#44/#48) with minimal friction.
+public struct Medication: Identifiable, Codable, Hashable, Sendable {
+    public var id: String
+    /// One vault = one encryption boundary. Carried from day one per repo convention.
+    public var vaultId: String
+    public var name: String
+    public var genericName: String?
+    public var dosage: String
+    public var form: MedicationForm
+    public var category: MedicationCategory
+    public var frequency: String
+    public var prescriber: String?
+    public var notes: String?
+    /// RxNorm concept id from the local drug index, when matched.
+    public var rxnormId: String?
+    /// Reference id linking to a `DrugReference`, when available.
+    public var drugReferenceId: String?
+
+    public init(
+        id: String = UUID().uuidString,
+        vaultId: String,
+        name: String,
+        genericName: String? = nil,
+        dosage: String,
+        form: MedicationForm = .tablet,
+        category: MedicationCategory = .prescription,
+        frequency: String = "Once daily",
+        prescriber: String? = nil,
+        notes: String? = nil,
+        rxnormId: String? = nil,
+        drugReferenceId: String? = nil
+    ) {
+        self.id = id
+        self.vaultId = vaultId
+        self.name = name
+        self.genericName = genericName
+        self.dosage = dosage
+        self.form = form
+        self.category = category
+        self.frequency = frequency
+        self.prescriber = prescriber
+        self.notes = notes
+        self.rxnormId = rxnormId
+        self.drugReferenceId = drugReferenceId
+    }
+
+    /// "Levothyroxine 88 mcg" — name plus dosage for compact display.
+    public var titleWithDosage: String { "\(name) \(dosage)" }
+}

--- a/ios/medication-list/PildoraMedicationList/Sources/PildoraMedicationList/Notifications/LocalRefillNotifier.swift
+++ b/ios/medication-list/PildoraMedicationList/Sources/PildoraMedicationList/Notifications/LocalRefillNotifier.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+#if os(iOS)
+import UserNotifications
+
+/// `RefillNotifying` backed by `UNUserNotificationCenter`.
+///
+/// Schedules **local** notifications only. Each medication maps to a single
+/// stable notification id, so re-scheduling replaces the previous reminder
+/// rather than stacking duplicates — this also keeps refill reminders within
+/// the reserved slots of the app's 64-notification budget (see the
+/// notification spike).
+public final class LocalRefillNotifier: RefillNotifying {
+    private let center: UNUserNotificationCenter
+    /// Delay before a freshly-triggered refill reminder fires, so it does not
+    /// interrupt the action that caused it (e.g. editing the count).
+    private let fireDelay: TimeInterval
+
+    public init(
+        center: UNUserNotificationCenter = .current(),
+        fireDelay: TimeInterval = 60 * 60
+    ) {
+        self.center = center
+        self.fireDelay = fireDelay
+    }
+
+    /// Request authorization for alerts/sounds/badges. Safe to call repeatedly.
+    public func requestAuthorization() async -> Bool {
+        (try? await center.requestAuthorization(options: [.alert, .sound, .badge])) ?? false
+    }
+
+    public func scheduleRefillReminder(_ reminder: RefillReminder) {
+        let content = UNMutableNotificationContent()
+        content.title = reminder.title
+        content.body = reminder.body
+        content.sound = .default
+        content.threadIdentifier = "refill"
+
+        let trigger = UNTimeIntervalNotificationTrigger(
+            timeInterval: max(1, fireDelay),
+            repeats: false
+        )
+        let request = UNNotificationRequest(
+            identifier: reminder.notificationID,
+            content: content,
+            trigger: trigger
+        )
+        // Replace any existing reminder for this medication first.
+        center.removePendingNotificationRequests(withIdentifiers: [reminder.notificationID])
+        center.add(request)
+    }
+
+    public func cancelRefillReminder(medicationID: String) {
+        let id = "refill.\(medicationID)"
+        center.removePendingNotificationRequests(withIdentifiers: [id])
+    }
+}
+#endif

--- a/ios/medication-list/PildoraMedicationList/Sources/PildoraMedicationList/Notifications/RefillNotifying.swift
+++ b/ios/medication-list/PildoraMedicationList/Sources/PildoraMedicationList/Notifications/RefillNotifying.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+// MARK: - Refill Reminder
+
+/// A request to remind the user to refill a medication that has run low.
+public struct RefillReminder: Equatable, Sendable {
+    public let medicationID: String
+    public let medicationName: String
+    public let remainingCount: Int
+    public let unitNoun: String
+
+    public init(medicationID: String, medicationName: String, remainingCount: Int, unitNoun: String) {
+        self.medicationID = medicationID
+        self.medicationName = medicationName
+        self.remainingCount = remainingCount
+        self.unitNoun = unitNoun
+    }
+
+    /// Stable per-medication notification identifier so re-evaluating replaces
+    /// (rather than duplicates) an existing reminder.
+    public var notificationID: String { "refill.\(medicationID)" }
+
+    public var title: String { "Refill \(medicationName)" }
+
+    public var body: String {
+        let unit = remainingCount == 1 ? unitNoun : "\(unitNoun)s"
+        return "Only \(remainingCount) \(unit) left. Time to request a refill."
+    }
+}
+
+// MARK: - RefillNotifying
+
+/// Abstraction over local refill notifications.
+///
+/// Refill reminders are **local notifications only** — the server never learns
+/// when a user is low on a medication (zero-knowledge constraint). The iOS
+/// implementation uses `UNUserNotificationCenter`; a simulated implementation
+/// is used for previews, tests, and the macOS toolchain build.
+public protocol RefillNotifying: AnyObject {
+    /// Schedule (or replace) a refill reminder for the reminder's medication.
+    func scheduleRefillReminder(_ reminder: RefillReminder)
+    /// Cancel any pending refill reminder for the given medication.
+    func cancelRefillReminder(medicationID: String)
+}
+
+// MARK: - Simulated implementation
+
+/// In-memory `RefillNotifying` used in previews, unit tests, and on platforms
+/// without `UserNotifications`. Records the current set of pending reminders so
+/// tests can assert scheduling behavior.
+public final class SimulatedRefillNotifier: RefillNotifying {
+    public private(set) var pending: [String: RefillReminder] = [:]
+
+    public init() {}
+
+    public func scheduleRefillReminder(_ reminder: RefillReminder) {
+        pending[reminder.medicationID] = reminder
+    }
+
+    public func cancelRefillReminder(medicationID: String) {
+        pending[medicationID] = nil
+    }
+
+    /// Convenience for assertions/UI: the pending reminders sorted by name.
+    public var pendingReminders: [RefillReminder] {
+        pending.values.sorted { $0.medicationName < $1.medicationName }
+    }
+}

--- a/ios/medication-list/PildoraMedicationList/Sources/PildoraMedicationList/Store/MedicationStore.swift
+++ b/ios/medication-list/PildoraMedicationList/Sources/PildoraMedicationList/Store/MedicationStore.swift
@@ -1,0 +1,213 @@
+import Foundation
+import Combine
+
+// MARK: - Grouped Section
+
+/// A category-grouped section of medications for the list view.
+public struct MedicationSection: Identifiable {
+    public let category: MedicationCategory
+    public let medications: [Medication]
+    public var id: MedicationCategory { category }
+}
+
+// MARK: - Medication Store
+
+/// In-memory, observable source of truth for the feature.
+///
+/// Holds medications, their inventory records, drug reference data and app
+/// settings, and derives the search-filtered, category-grouped list the UI
+/// renders. Designed to be replaced by a GRDB/SQLCipher-backed store (#44/#48)
+/// without changing the views: the published surface is what the views depend
+/// on.
+@MainActor
+public final class MedicationStore: ObservableObject {
+
+    // MARK: Published state
+
+    @Published public private(set) var medications: [Medication]
+    @Published public private(set) var inventoryByMedication: [String: InventoryRecord]
+    @Published public private(set) var referencesById: [String: DrugReference]
+    @Published public var settings: AppSettings
+    /// Search text bound to the list's search field. Matches name + generic name.
+    @Published public var searchText: String = ""
+
+    private let notifier: RefillNotifying
+
+    // MARK: Init
+
+    public init(
+        medications: [Medication],
+        inventory: [InventoryRecord],
+        references: [DrugReference],
+        settings: AppSettings = .default,
+        notifier: RefillNotifying = SimulatedRefillNotifier()
+    ) {
+        self.medications = medications
+        self.inventoryByMedication = Dictionary(
+            uniqueKeysWithValues: inventory.map { ($0.medicationId, $0) }
+        )
+        self.referencesById = Dictionary(
+            uniqueKeysWithValues: references.map { ($0.id, $0) }
+        )
+        self.settings = settings
+        self.notifier = notifier
+    }
+
+    /// Convenience initializer seeded with bundled sample data.
+    public static func sample(notifier: RefillNotifying = SimulatedRefillNotifier()) -> MedicationStore {
+        MedicationStore(
+            medications: SampleData.medications,
+            inventory: SampleData.inventory(),
+            references: SampleData.drugReferences(),
+            notifier: notifier
+        )
+    }
+
+    // MARK: Lookups
+
+    public func inventory(for medicationID: String) -> InventoryRecord? {
+        inventoryByMedication[medicationID]
+    }
+
+    public func reference(for medication: Medication) -> DrugReference? {
+        guard let refID = medication.drugReferenceId else { return nil }
+        return referencesById[refID]
+    }
+
+    // MARK: Search + grouping
+
+    /// Medications matching the current `searchText` (case/diacritic-insensitive,
+    /// over name and generic name). Empty search returns all.
+    public var filteredMedications: [Medication] {
+        Self.filter(medications, query: searchText)
+    }
+
+    /// Static, side-effect-free filter used by the view and unit tests.
+    nonisolated public static func filter(_ meds: [Medication], query: String) -> [Medication] {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return meds }
+        return meds.filter { med in
+            med.name.localizedCaseInsensitiveContains(trimmed)
+                || (med.genericName?.localizedCaseInsensitiveContains(trimmed) ?? false)
+        }
+    }
+
+    /// The filtered medications grouped into category sections, each sorted by
+    /// name, with sections ordered by `MedicationCategory.sortOrder`.
+    public var sections: [MedicationSection] {
+        Self.group(filteredMedications)
+    }
+
+    /// Static, side-effect-free grouping used by the view and unit tests.
+    nonisolated public static func group(_ meds: [Medication]) -> [MedicationSection] {
+        let grouped = Dictionary(grouping: meds, by: { $0.category })
+        return grouped
+            .map { category, meds in
+                MedicationSection(
+                    category: category,
+                    medications: meds.sorted { $0.name.localizedCaseInsensitiveCompare($1.name) == .orderedAscending }
+                )
+            }
+            .sorted { $0.category.sortOrder < $1.category.sortOrder }
+    }
+
+    // MARK: Low stock
+
+    /// Medications currently at or below their refill threshold.
+    public var lowStockMedications: [Medication] {
+        medications.filter { med in
+            inventoryByMedication[med.id]?.isLow ?? false
+        }
+    }
+
+    // MARK: Inventory mutation
+
+    /// Set the absolute inventory count for a medication, re-evaluating the
+    /// refill reminder. Creates an inventory record if none exists.
+    public func setInventoryCount(_ count: Int, for medicationID: String) {
+        let clamped = max(0, count)
+        var record = inventoryByMedication[medicationID]
+            ?? InventoryRecord(
+                medicationId: medicationID,
+                currentCount: clamped,
+                refillThreshold: settings.defaultRefillThreshold
+            )
+        record.currentCount = clamped
+        record.updatedAt = Date()
+        inventoryByMedication[medicationID] = record
+        reevaluateRefill(for: medicationID)
+    }
+
+    /// Adjust inventory by a delta (e.g. +1 / -1 stepper).
+    public func adjustInventory(by delta: Int, for medicationID: String) {
+        let current = inventoryByMedication[medicationID]?.currentCount ?? 0
+        setInventoryCount(current + delta, for: medicationID)
+    }
+
+    /// Update the user-configurable refill threshold for a medication.
+    public func setRefillThreshold(_ threshold: Int, for medicationID: String) {
+        guard var record = inventoryByMedication[medicationID] else { return }
+        record.refillThreshold = max(0, threshold)
+        record.updatedAt = Date()
+        inventoryByMedication[medicationID] = record
+        reevaluateRefill(for: medicationID)
+    }
+
+    /// Toggle whether a refill reminder is scheduled for a medication.
+    public func setRefillReminderEnabled(_ enabled: Bool, for medicationID: String) {
+        guard var record = inventoryByMedication[medicationID] else { return }
+        record.refillReminderEnabled = enabled
+        inventoryByMedication[medicationID] = record
+        reevaluateRefill(for: medicationID)
+    }
+
+    /// Record a refill: set the count and stamp the refill date.
+    public func recordRefill(newCount: Int, for medicationID: String, date: Date = Date()) {
+        var record = inventoryByMedication[medicationID]
+            ?? InventoryRecord(
+                medicationId: medicationID,
+                currentCount: newCount,
+                refillThreshold: settings.defaultRefillThreshold
+            )
+        record.currentCount = max(0, newCount)
+        record.lastRefillDate = date
+        record.updatedAt = date
+        inventoryByMedication[medicationID] = record
+        reevaluateRefill(for: medicationID)
+    }
+
+    // MARK: Refill notification scheduling
+
+    /// Schedule or cancel the local refill reminder for a medication based on
+    /// its current inventory state and the app-wide setting.
+    private func reevaluateRefill(for medicationID: String) {
+        guard let med = medications.first(where: { $0.id == medicationID }),
+              let record = inventoryByMedication[medicationID]
+        else { return }
+
+        let shouldNotify = settings.refillRemindersEnabled
+            && record.refillReminderEnabled
+            && record.isLow
+
+        if shouldNotify {
+            notifier.scheduleRefillReminder(
+                RefillReminder(
+                    medicationID: med.id,
+                    medicationName: med.name,
+                    remainingCount: record.currentCount,
+                    unitNoun: med.form.unitNoun
+                )
+            )
+        } else {
+            notifier.cancelRefillReminder(medicationID: medicationID)
+        }
+    }
+
+    /// Re-evaluate refill reminders for every medication. Call on launch /
+    /// foreground to bring the notification queue in sync with current state.
+    public func reevaluateAllRefills() {
+        for med in medications {
+            reevaluateRefill(for: med.id)
+        }
+    }
+}

--- a/ios/medication-list/PildoraMedicationList/Sources/PildoraMedicationList/Store/SampleData.swift
+++ b/ios/medication-list/PildoraMedicationList/Sources/PildoraMedicationList/Store/SampleData.swift
@@ -1,0 +1,139 @@
+import Foundation
+
+// MARK: - Sample Data
+
+/// Seeded in-memory data backing the feature while the real persistence layer
+/// (#44/#48) and drug index (ETL output) are still in progress.
+///
+/// Chosen to exercise edge cases: prescriptions, OTC, supplements and vitamins;
+/// a very long name (Dynamic Type wrapping); critical and low inventory; and a
+/// medication without reference data.
+public enum SampleData {
+
+    public static let vaultId = "vault-default"
+
+    /// Drug reference entries keyed by their `id`. Public, plaintext data.
+    public static func drugReferences(now: Date = Date()) -> [DrugReference] {
+        let cal = Calendar.current
+        let fdaDate = cal.date(byAdding: .day, value: -45, to: now) ?? now
+        let rxnormDate = cal.date(byAdding: .day, value: -60, to: now) ?? now
+        return [
+            DrugReference(
+                id: "ref-levothyroxine",
+                drugClass: "Thyroid hormone (levothyroxine sodium)",
+                commonSideEffects: ["Headache", "Insomnia", "Palpitations", "Weight changes"],
+                source: "openFDA",
+                sourceDate: fdaDate
+            ),
+            DrugReference(
+                id: "ref-metformin",
+                drugClass: "Biguanide (antidiabetic)",
+                commonSideEffects: ["Nausea", "Diarrhea", "Abdominal discomfort", "Metallic taste"],
+                source: "openFDA",
+                sourceDate: fdaDate
+            ),
+            DrugReference(
+                id: "ref-vitamin-d3",
+                drugClass: "Fat-soluble vitamin (cholecalciferol)",
+                commonSideEffects: ["Generally well tolerated at recommended intake"],
+                source: "RxNorm",
+                sourceDate: rxnormDate
+            ),
+            DrugReference(
+                id: "ref-gabapentin",
+                drugClass: "Anticonvulsant / nerve pain (GABA analog)",
+                commonSideEffects: ["Drowsiness", "Dizziness", "Peripheral edema", "Fatigue"],
+                source: "openFDA",
+                sourceDate: fdaDate
+            ),
+        ]
+    }
+
+    public static let medications: [Medication] = [
+        Medication(
+            id: "med-1",
+            vaultId: vaultId,
+            name: "Levothyroxine",
+            genericName: nil,
+            dosage: "88 mcg",
+            form: .tablet,
+            category: .prescription,
+            frequency: "Once daily, morning on empty stomach",
+            prescriber: "Dr. Chen",
+            rxnormId: "10582",
+            drugReferenceId: "ref-levothyroxine"
+        ),
+        Medication(
+            id: "med-2",
+            vaultId: vaultId,
+            name: "Metformin",
+            genericName: "metformin hydrochloride",
+            dosage: "500 mg",
+            form: .tablet,
+            category: .prescription,
+            frequency: "Twice daily with meals",
+            prescriber: "Dr. Patel",
+            rxnormId: "6809",
+            drugReferenceId: "ref-metformin"
+        ),
+        Medication(
+            id: "med-3",
+            vaultId: vaultId,
+            name: "Cholecalciferol (Vitamin D3)",
+            genericName: "cholecalciferol",
+            dosage: "5,000 IU",
+            form: .capsule,
+            category: .vitamin,
+            frequency: "Once daily",
+            drugReferenceId: "ref-vitamin-d3"
+        ),
+        Medication(
+            id: "med-4",
+            vaultId: vaultId,
+            name: "Magnesium Glycinate",
+            genericName: nil,
+            dosage: "400 mg",
+            form: .capsule,
+            category: .supplement,
+            frequency: "Once daily at bedtime"
+        ),
+        Medication(
+            id: "med-5",
+            vaultId: vaultId,
+            name: "Gabapentin",
+            genericName: nil,
+            dosage: "300 mg",
+            form: .capsule,
+            category: .prescription,
+            frequency: "Three times daily",
+            prescriber: "Dr. Rivera",
+            rxnormId: "25480",
+            drugReferenceId: "ref-gabapentin"
+        ),
+        Medication(
+            id: "med-6",
+            vaultId: vaultId,
+            name: "Ibuprofen",
+            genericName: nil,
+            dosage: "200 mg",
+            form: .tablet,
+            category: .overTheCounter,
+            frequency: "As needed for pain"
+        ),
+    ]
+
+    public static func inventory(now: Date = Date()) -> [InventoryRecord] {
+        let cal = Calendar.current
+        return [
+            InventoryRecord(medicationId: "med-1", currentCount: 22, refillThreshold: 7,
+                            lastRefillDate: cal.date(byAdding: .day, value: -8, to: now)),
+            InventoryRecord(medicationId: "med-2", currentCount: 45, refillThreshold: 10,
+                            lastRefillDate: cal.date(byAdding: .day, value: -2, to: now)),
+            InventoryRecord(medicationId: "med-3", currentCount: 90, refillThreshold: 14),
+            // Low + critical: drives the low-stock alert + refill reminder paths.
+            InventoryRecord(medicationId: "med-4", currentCount: 3, refillThreshold: 7),
+            InventoryRecord(medicationId: "med-5", currentCount: 15, refillThreshold: 9),
+            InventoryRecord(medicationId: "med-6", currentCount: 24, refillThreshold: 5),
+        ]
+    }
+}

--- a/ios/medication-list/PildoraMedicationList/Sources/PildoraMedicationList/Views/DrugReferenceSection.swift
+++ b/ios/medication-list/PildoraMedicationList/Sources/PildoraMedicationList/Views/DrugReferenceSection.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+
+// MARK: - Drug Reference Section
+
+/// Displays basic, plaintext drug reference data for a medication: drug class,
+/// common side effects, **source + date attribution**, and the required
+/// informational-only disclaimer.
+///
+/// Risk: 🟡 Informational. Presents published reference data only — never
+/// dosing or diagnostic guidance.
+struct DrugReferenceSection: View {
+    let reference: DrugReference?
+
+    var body: some View {
+        Section {
+            if let reference {
+                VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+                    labeledRow(label: "Drug class", value: reference.drugClass)
+
+                    if !reference.commonSideEffects.isEmpty {
+                        VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
+                            Text("Common side effects")
+                                .font(Typography.caption.weight(.semibold))
+                                .foregroundStyle(Theme.Colors.textSecondary)
+                            Text(reference.commonSideEffects.joined(separator: ", "))
+                                .font(Typography.body)
+                                .foregroundStyle(Theme.Colors.textPrimary)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                        .accessibilityElement(children: .combine)
+                    }
+
+                    SourceTag(reference.attribution())
+
+                    Text(DrugReference.disclaimer)
+                        .font(Typography.caption)
+                        .italic()
+                        .foregroundStyle(Theme.Colors.textSecondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .padding(.vertical, Theme.Spacing.xxs)
+            } else {
+                Text("No reference information available for this item.")
+                    .font(Typography.body)
+                    .foregroundStyle(Theme.Colors.textSecondary)
+            }
+        } header: {
+            Text("Reference")
+                .accessibilityAddTraits(.isHeader)
+        }
+    }
+
+    private func labeledRow(label: String, value: String) -> some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
+            Text(label)
+                .font(Typography.caption.weight(.semibold))
+                .foregroundStyle(Theme.Colors.textSecondary)
+            Text(value)
+                .font(Typography.body)
+                .foregroundStyle(Theme.Colors.textPrimary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .accessibilityElement(children: .combine)
+    }
+}

--- a/ios/medication-list/PildoraMedicationList/Sources/PildoraMedicationList/Views/ExportView.swift
+++ b/ios/medication-list/PildoraMedicationList/Sources/PildoraMedicationList/Views/ExportView.swift
@@ -1,0 +1,94 @@
+import SwiftUI
+
+// MARK: - Export View
+
+/// Data export screen. Generates a full **decrypted JSON** export of all user
+/// data and a **Doctor Mode PDF** summary — both produced entirely on-device.
+/// Files are shared via the system share sheet (`ShareLink`); nothing is sent
+/// to a server.
+struct ExportView: View {
+    @ObservedObject var store: MedicationStore
+
+    @State private var jsonURL: URL?
+    @State private var pdfURL: URL?
+    @State private var jsonPreview: String = ""
+    @State private var errorMessage: String?
+
+    var body: some View {
+        List {
+            Section {
+                if let jsonURL {
+                    ShareLink(item: jsonURL) {
+                        Label("Export full data (JSON)", systemImage: "square.and.arrow.up")
+                    }
+                } else {
+                    Label("Preparing JSON…", systemImage: "hourglass")
+                        .foregroundStyle(Theme.Colors.textSecondary)
+                }
+                if let pdfURL {
+                    ShareLink(item: pdfURL) {
+                        Label("Export summary (PDF · Doctor Mode)", systemImage: "doc.richtext")
+                    }
+                } else {
+                    Label("Preparing PDF…", systemImage: "hourglass")
+                        .foregroundStyle(Theme.Colors.textSecondary)
+                }
+            } header: {
+                Text("Export")
+                    .accessibilityAddTraits(.isHeader)
+            } footer: {
+                Text("Exports are generated on your device. Pildora does not upload your data. The JSON export is decrypted — store it somewhere safe.")
+            }
+
+            if let errorMessage {
+                Section {
+                    Label(errorMessage, systemImage: "exclamationmark.triangle")
+                        .foregroundStyle(Theme.Colors.error)
+                }
+            }
+
+            if !jsonPreview.isEmpty {
+                Section("JSON preview") {
+                    Text(jsonPreview)
+                        .font(.system(.caption, design: .monospaced))
+                        .textSelection(.enabled)
+                        .accessibilityLabel("JSON export preview")
+                }
+            }
+        }
+        .navigationTitle("Export")
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+        .task { await prepareExports() }
+    }
+
+    private func prepareExports() async {
+        let document = DataExporter.document(from: store)
+        do {
+            let jsonData = try DataExporter.jsonData(for: document)
+            jsonPreview = String(decoding: jsonData.prefix(2000), as: UTF8.self)
+            jsonURL = try writeTemp(
+                data: jsonData,
+                filename: DataExporter.suggestedFilename(ext: "json")
+            )
+
+            let report = DoctorReport.build(from: store)
+            let pdfData = PDFReportRenderer.render(report)
+            // On non-UIKit platforms this is plain text; keep the extension honest.
+            let pdfExt = pdfData.starts(with: Array("%PDF".utf8)) ? "pdf" : "txt"
+            pdfURL = try writeTemp(
+                data: pdfData,
+                filename: DataExporter.suggestedFilename(ext: pdfExt)
+            )
+        } catch {
+            errorMessage = "Could not prepare export: \(error.localizedDescription)"
+        }
+    }
+
+    private func writeTemp(data: Data, filename: String) throws -> URL {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(filename)
+        try data.write(to: url, options: .atomic)
+        return url
+    }
+}

--- a/ios/medication-list/PildoraMedicationList/Sources/PildoraMedicationList/Views/InventoryEditorView.swift
+++ b/ios/medication-list/PildoraMedicationList/Sources/PildoraMedicationList/Views/InventoryEditorView.swift
@@ -1,0 +1,110 @@
+import SwiftUI
+
+// MARK: - Inventory Editor View
+
+/// Manual inventory controls for a medication: current count stepper, a
+/// user-configurable refill threshold, a refill-reminder toggle, and a
+/// "Record refill" action. Embedded as a section in the detail screen.
+struct InventoryEditorView: View {
+    @ObservedObject var store: MedicationStore
+    let medicationID: String
+    let unitNoun: String
+
+    @State private var showRecordRefill = false
+    @State private var refillAmount = 30
+
+    private var inventory: InventoryRecord? { store.inventory(for: medicationID) }
+
+    var body: some View {
+        Section {
+            countStepper
+            thresholdStepper
+            reminderToggle
+            recordRefillButton
+        } header: {
+            Text("Inventory")
+                .accessibilityAddTraits(.isHeader)
+        } footer: {
+            if let inventory, inventory.isLow {
+                Label(
+                    inventory.isCritical
+                        ? "Critically low — refill soon."
+                        : "Low stock — consider a refill.",
+                    systemImage: "exclamationmark.triangle.fill"
+                )
+                .font(Typography.caption)
+                .foregroundStyle(inventory.isCritical ? Theme.Colors.error : Theme.Colors.warning)
+            }
+        }
+        .alert("Record refill", isPresented: $showRecordRefill) {
+            TextField("New count", value: $refillAmount, format: .number)
+                #if os(iOS)
+                .keyboardType(.numberPad)
+                #endif
+            Button("Cancel", role: .cancel) {}
+            Button("Save") {
+                store.recordRefill(newCount: refillAmount, for: medicationID)
+            }
+        } message: {
+            Text("Set the total \(unitNoun) count after refilling.")
+        }
+    }
+
+    private var countStepper: some View {
+        let count = inventory?.currentCount ?? 0
+        return Stepper(
+            value: Binding(
+                get: { inventory?.currentCount ?? 0 },
+                set: { store.setInventoryCount($0, for: medicationID) }
+            ),
+            in: 0...9999
+        ) {
+            HStack {
+                Text("On hand")
+                Spacer()
+                Text("\(count) \(count == 1 ? unitNoun : "\(unitNoun)s")")
+                    .foregroundStyle(Theme.Colors.textSecondary)
+            }
+        }
+        .accessibilityLabel("On hand: \(count) \(unitNoun)")
+    }
+
+    private var thresholdStepper: some View {
+        let threshold = inventory?.refillThreshold ?? store.settings.defaultRefillThreshold
+        return Stepper(
+            value: Binding(
+                get: { inventory?.refillThreshold ?? store.settings.defaultRefillThreshold },
+                set: { store.setRefillThreshold($0, for: medicationID) }
+            ),
+            in: 0...999
+        ) {
+            HStack {
+                Text("Refill alert at")
+                Spacer()
+                Text("\(threshold) \(threshold == 1 ? unitNoun : "\(unitNoun)s")")
+                    .foregroundStyle(Theme.Colors.textSecondary)
+            }
+        }
+        .accessibilityLabel("Refill alert threshold: \(threshold) \(unitNoun)")
+    }
+
+    private var reminderToggle: some View {
+        Toggle(
+            "Refill reminder",
+            isOn: Binding(
+                get: { inventory?.refillReminderEnabled ?? false },
+                set: { store.setRefillReminderEnabled($0, for: medicationID) }
+            )
+        )
+        .disabled(inventory == nil)
+    }
+
+    private var recordRefillButton: some View {
+        Button {
+            refillAmount = max(inventory?.refillThreshold ?? 30, 30)
+            showRecordRefill = true
+        } label: {
+            Label("Record refill", systemImage: "arrow.clockwise")
+        }
+    }
+}

--- a/ios/medication-list/PildoraMedicationList/Sources/PildoraMedicationList/Views/MedicationDetailView.swift
+++ b/ios/medication-list/PildoraMedicationList/Sources/PildoraMedicationList/Views/MedicationDetailView.swift
@@ -1,0 +1,93 @@
+import SwiftUI
+
+// MARK: - Medication Detail View
+
+/// Detail screen for a single medication: header (name, dosage, form,
+/// frequency, prescriber/notes), inventory editor, and the drug reference
+/// section with source attribution and disclaimer.
+struct MedicationDetailView: View {
+    @ObservedObject var store: MedicationStore
+    let medicationID: String
+
+    private var medication: Medication? {
+        store.medications.first { $0.id == medicationID }
+    }
+
+    var body: some View {
+        Group {
+            if let medication {
+                List {
+                    headerSection(medication)
+                    InventoryEditorView(
+                        store: store,
+                        medicationID: medication.id,
+                        unitNoun: medication.form.unitNoun
+                    )
+                    DrugReferenceSection(reference: store.reference(for: medication))
+                }
+                .groupedListStyle()
+                .navigationTitle(medication.name)
+                #if os(iOS)
+                .navigationBarTitleDisplayMode(.inline)
+                #endif
+            } else {
+                ContentUnavailableView("Medication not found", systemImage: "pills")
+            }
+        }
+    }
+
+    private func headerSection(_ medication: Medication) -> some View {
+        Section {
+            VStack(alignment: .leading, spacing: Theme.Spacing.sm) {
+                Text(medication.titleWithDosage)
+                    .font(.title2.weight(.semibold))
+                    .fixedSize(horizontal: false, vertical: true)
+
+                StatusBadge(medication.category.displayName, level: .info)
+
+                detailRow(label: "Form", value: medication.form.displayName)
+                detailRow(label: "Frequency", value: medication.frequency)
+                if let generic = medication.genericName {
+                    detailRow(label: "Generic", value: generic)
+                }
+                if let prescriber = medication.prescriber {
+                    detailRow(label: "Prescriber", value: prescriber)
+                }
+                if let notes = medication.notes, !notes.isEmpty {
+                    detailRow(label: "Notes", value: notes)
+                }
+            }
+            .padding(.vertical, Theme.Spacing.xxs)
+        }
+    }
+
+    private func detailRow(label: String, value: String) -> some View {
+        HStack(alignment: .firstTextBaseline) {
+            Text(label)
+                .font(Typography.caption.weight(.semibold))
+                .foregroundStyle(Theme.Colors.textSecondary)
+            Spacer(minLength: Theme.Spacing.md)
+            Text(value)
+                .font(Typography.body)
+                .foregroundStyle(Theme.Colors.textPrimary)
+                .multilineTextAlignment(.trailing)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(label): \(value)")
+    }
+}
+
+#if DEBUG
+#Preview("Detail") {
+    NavigationStack {
+        MedicationDetailView(store: .sample(), medicationID: "med-2")
+    }
+}
+
+#Preview("Detail · Low stock") {
+    NavigationStack {
+        MedicationDetailView(store: .sample(), medicationID: "med-4")
+    }
+}
+#endif

--- a/ios/medication-list/PildoraMedicationList/Sources/PildoraMedicationList/Views/MedicationListView.swift
+++ b/ios/medication-list/PildoraMedicationList/Sources/PildoraMedicationList/Views/MedicationListView.swift
@@ -1,0 +1,114 @@
+import SwiftUI
+
+// MARK: - Medication List View
+
+/// The primary medication list: a scrollable, category-grouped list of all
+/// medications with search/filter by name, low-inventory indicators, and
+/// navigation to per-medication detail. The toolbar links to the profile /
+/// export screen.
+public struct MedicationListView: View {
+    @ObservedObject private var store: MedicationStore
+
+    public init(store: MedicationStore) {
+        self.store = store
+    }
+
+    public var body: some View {
+        NavigationStack {
+            Group {
+                if store.medications.isEmpty {
+                    emptyState
+                } else if store.sections.isEmpty {
+                    noResultsState
+                } else {
+                    list
+                }
+            }
+            .navigationTitle("Medications")
+            .toolbar {
+                ToolbarItem(placement: .primaryAction) {
+                    NavigationLink {
+                        ProfileView(store: store)
+                    } label: {
+                        Image(systemName: "person.crop.circle")
+                            .accessibilityLabel("Profile and settings")
+                    }
+                }
+            }
+        }
+        .searchable(text: $store.searchText, prompt: "Search medications")
+    }
+
+    private var list: some View {
+        List {
+            if !store.lowStockMedications.isEmpty {
+                lowStockSummary
+            }
+            ForEach(store.sections) { section in
+                Section {
+                    ForEach(section.medications) { med in
+                        NavigationLink {
+                            MedicationDetailView(store: store, medicationID: med.id)
+                        } label: {
+                            MedicationRow(medication: med, inventory: store.inventory(for: med.id))
+                        }
+                    }
+                } header: {
+                    Text(section.category.displayName)
+                        .accessibilityAddTraits(.isHeader)
+                }
+            }
+        }
+        .groupedListStyle()
+    }
+
+    private var lowStockSummary: some View {
+        Section {
+            HStack(spacing: Theme.Spacing.sm) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(Theme.Colors.warning)
+                    .accessibilityHidden(true)
+                Text(lowStockSummaryText)
+                    .font(Typography.caption)
+                    .foregroundStyle(Theme.Colors.textPrimary)
+            }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(lowStockSummaryText)
+        }
+    }
+
+    private var lowStockSummaryText: String {
+        let count = store.lowStockMedications.count
+        return count == 1
+            ? "1 medication is low and needs a refill"
+            : "\(count) medications are low and need a refill"
+    }
+
+    private var emptyState: some View {
+        ContentUnavailableView(
+            "No Medications",
+            systemImage: "pills",
+            description: Text("Medications you add will appear here.")
+        )
+    }
+
+    private var noResultsState: some View {
+        ContentUnavailableView.search(text: store.searchText)
+    }
+}
+
+#if DEBUG
+#Preview("List") {
+    MedicationListView(store: .sample())
+}
+
+#Preview("List · Dark") {
+    MedicationListView(store: .sample())
+        .preferredColorScheme(.dark)
+}
+
+#Preview("List · xxxLarge") {
+    MedicationListView(store: .sample())
+        .environment(\.dynamicTypeSize, .xxxLarge)
+}
+#endif

--- a/ios/medication-list/PildoraMedicationList/Sources/PildoraMedicationList/Views/MedicationRow.swift
+++ b/ios/medication-list/PildoraMedicationList/Sources/PildoraMedicationList/Views/MedicationRow.swift
@@ -1,0 +1,64 @@
+import SwiftUI
+
+// MARK: - Medication Row
+
+/// A single medication row in the list: name + dosage, form + frequency, and
+/// an inventory status badge when stock is low.
+struct MedicationRow: View {
+    let medication: Medication
+    let inventory: InventoryRecord?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Theme.Spacing.xs) {
+            HStack(alignment: .firstTextBaseline, spacing: Theme.Spacing.sm) {
+                Text(medication.name)
+                    .font(Typography.cardTitle)
+                    .foregroundStyle(Theme.Colors.textPrimary)
+                    .fixedSize(horizontal: false, vertical: true)
+                Spacer(minLength: Theme.Spacing.xs)
+                Text(medication.dosage)
+                    .font(Typography.cardSubtitle)
+                    .foregroundStyle(Theme.Colors.textSecondary)
+            }
+
+            Text("\(medication.form.displayName) · \(medication.frequency)")
+                .font(Typography.cardSubtitle)
+                .foregroundStyle(Theme.Colors.textSecondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            if let generic = medication.genericName {
+                Text(generic)
+                    .font(Typography.caption)
+                    .foregroundStyle(Theme.Colors.textSecondary)
+            }
+
+            if let inventory, inventory.isLow {
+                StatusBadge(
+                    inventory.isCritical
+                        ? "Critical: \(inventory.currentCount) left"
+                        : "Low: \(inventory.currentCount) left",
+                    level: inventory.isCritical ? .error : .warning
+                )
+            }
+        }
+        .padding(.vertical, Theme.Spacing.xxs)
+        .frame(minHeight: 44)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityLabel)
+        .accessibilityHint("Double tap to view details")
+        .accessibilityAddTraits(.isButton)
+    }
+
+    private var accessibilityLabel: String {
+        var parts = ["\(medication.name), \(medication.dosage) \(medication.form.displayName)"]
+        if let generic = medication.genericName {
+            parts.append("generic \(generic)")
+        }
+        parts.append(medication.frequency)
+        if let inventory, inventory.isLow {
+            let severity = inventory.isCritical ? "Critically low" : "Low"
+            parts.append("\(severity), \(inventory.currentCount) remaining")
+        }
+        return parts.joined(separator: ". ")
+    }
+}

--- a/ios/medication-list/PildoraMedicationList/Sources/PildoraMedicationList/Views/PreviewCatalog.swift
+++ b/ios/medication-list/PildoraMedicationList/Sources/PildoraMedicationList/Views/PreviewCatalog.swift
@@ -1,0 +1,68 @@
+import SwiftUI
+
+// MARK: - Root Feature View
+
+/// Convenience entry point that wires a `MedicationStore` into the medication
+/// list and re-evaluates refill reminders when the feature appears.
+public struct MedicationFeatureView: View {
+    @StateObject private var store: MedicationStore
+
+    public init(store: @autoclosure @escaping () -> MedicationStore) {
+        _store = StateObject(wrappedValue: store())
+    }
+
+    /// Sample-data entry point for previews / demos.
+    public init() {
+        _store = StateObject(wrappedValue: .sample())
+    }
+
+    public var body: some View {
+        MedicationListView(store: store)
+            .preferredColorScheme(colorScheme)
+            .task { store.reevaluateAllRefills() }
+    }
+
+    private var colorScheme: ColorScheme? {
+        switch store.settings.preferredAppearance {
+        case .system: return nil
+        case .light: return .light
+        case .dark: return .dark
+        }
+    }
+}
+
+// MARK: - Preview Catalog
+
+#if DEBUG
+/// A catalog of previews exercising Dynamic Type, dark mode, and key states —
+/// used to visually verify accessibility requirements across the feature.
+enum PreviewCatalog {}
+
+#Preview("Feature · Default") {
+    MedicationFeatureView()
+}
+
+#Preview("Feature · Dark") {
+    MedicationFeatureView()
+        .preferredColorScheme(.dark)
+}
+
+#Preview("Feature · Accessibility XL") {
+    MedicationFeatureView()
+        .environment(\.dynamicTypeSize, .accessibility3)
+}
+
+#Preview("Components") {
+    List {
+        Section("Status badges") {
+            StatusBadge("Critical: 2 left", level: .error)
+            StatusBadge("Low: 6 left", level: .warning)
+            StatusBadge("Prescription", level: .info)
+            StatusBadge("In stock", level: .success)
+        }
+        Section("Source tag") {
+            SourceTag("Source: openFDA · Jan 12, 2026")
+        }
+    }
+}
+#endif

--- a/ios/medication-list/PildoraMedicationList/Sources/PildoraMedicationList/Views/ProfileView.swift
+++ b/ios/medication-list/PildoraMedicationList/Sources/PildoraMedicationList/Views/ProfileView.swift
@@ -1,0 +1,80 @@
+import SwiftUI
+
+// MARK: - Profile View
+
+/// Profile screen: a low-stock overview, plus navigation to settings and data
+/// export. Acts as the hub for app-level configuration and Doctor Mode export.
+struct ProfileView: View {
+    @ObservedObject var store: MedicationStore
+
+    var body: some View {
+        List {
+            Section {
+                summaryRow(
+                    icon: "pills.fill",
+                    title: "Tracked items",
+                    value: "\(store.medications.count)"
+                )
+                summaryRow(
+                    icon: "exclamationmark.triangle.fill",
+                    title: "Low on stock",
+                    value: "\(store.lowStockMedications.count)",
+                    emphasize: !store.lowStockMedications.isEmpty
+                )
+            } header: {
+                Text("Overview")
+                    .accessibilityAddTraits(.isHeader)
+            }
+
+            Section {
+                NavigationLink {
+                    SettingsView(store: store)
+                } label: {
+                    Label("Settings", systemImage: "gearshape")
+                }
+                NavigationLink {
+                    ExportView(store: store)
+                } label: {
+                    Label("Export data", systemImage: "square.and.arrow.up")
+                }
+            }
+
+            Section {
+                Text(DrugReference.disclaimer)
+                    .font(Typography.caption)
+                    .foregroundStyle(Theme.Colors.textSecondary)
+            } footer: {
+                Text("Pildora is a tracking tool, not a source of medical advice.")
+            }
+        }
+        .groupedListStyle()
+        .navigationTitle("Profile")
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+    }
+
+    private func summaryRow(icon: String, title: String, value: String, emphasize: Bool = false) -> some View {
+        HStack(spacing: Theme.Spacing.md) {
+            Image(systemName: icon)
+                .foregroundStyle(emphasize ? Theme.Colors.warning : Theme.Colors.primary)
+                .accessibilityHidden(true)
+            Text(title)
+            Spacer()
+            Text(value)
+                .font(Typography.body.weight(.semibold))
+                .foregroundStyle(emphasize ? Theme.Colors.warning : Theme.Colors.textPrimary)
+        }
+        .frame(minHeight: 44)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(title): \(value)")
+    }
+}
+
+#if DEBUG
+#Preview("Profile") {
+    NavigationStack {
+        ProfileView(store: .sample())
+    }
+}
+#endif

--- a/ios/medication-list/PildoraMedicationList/Sources/PildoraMedicationList/Views/SettingsView.swift
+++ b/ios/medication-list/PildoraMedicationList/Sources/PildoraMedicationList/Views/SettingsView.swift
@@ -1,0 +1,46 @@
+import SwiftUI
+
+// MARK: - Settings View
+
+/// App settings surfaced on the profile screen: default refill threshold,
+/// app-wide refill reminders toggle, and appearance preference.
+struct SettingsView: View {
+    @ObservedObject var store: MedicationStore
+
+    var body: some View {
+        Form {
+            Section {
+                Stepper(value: $store.settings.defaultRefillThreshold, in: 0...999) {
+                    HStack {
+                        Text("Default refill alert")
+                        Spacer()
+                        Text("\(store.settings.defaultRefillThreshold)")
+                            .foregroundStyle(Theme.Colors.textSecondary)
+                    }
+                }
+                .accessibilityLabel("Default refill alert threshold: \(store.settings.defaultRefillThreshold) units")
+
+                Toggle("Refill reminders", isOn: $store.settings.refillRemindersEnabled)
+                    .onChange(of: store.settings.refillRemindersEnabled) { _, _ in
+                        store.reevaluateAllRefills()
+                    }
+            } header: {
+                Text("Inventory")
+            } footer: {
+                Text("Refill reminders are delivered as local notifications only. Pildora never sends your medication or schedule data to a server.")
+            }
+
+            Section("Appearance") {
+                Picker("Theme", selection: $store.settings.preferredAppearance) {
+                    ForEach(AppSettings.Appearance.allCases, id: \.self) { appearance in
+                        Text(appearance.displayName).tag(appearance)
+                    }
+                }
+            }
+        }
+        .navigationTitle("Settings")
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+    }
+}

--- a/ios/medication-list/PildoraMedicationList/Tests/PildoraMedicationListTests/InventoryThresholdTests.swift
+++ b/ios/medication-list/PildoraMedicationList/Tests/PildoraMedicationListTests/InventoryThresholdTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+@testable import PildoraMedicationList
+
+@MainActor
+final class InventoryThresholdTests: XCTestCase {
+
+    private func makeStore(notifier: SimulatedRefillNotifier = .init()) -> MedicationStore {
+        MedicationStore(
+            medications: SampleData.medications,
+            inventory: SampleData.inventory(),
+            references: SampleData.drugReferences(),
+            notifier: notifier
+        )
+    }
+
+    func testIsLowAndCriticalDerivation() {
+        var rec = InventoryRecord(medicationId: "m", currentCount: 7, refillThreshold: 7)
+        XCTAssertTrue(rec.isLow)
+        rec.currentCount = 8
+        XCTAssertFalse(rec.isLow)
+        // Critical: <= max(3, threshold/2).
+        rec = InventoryRecord(medicationId: "m", currentCount: 3, refillThreshold: 7)
+        XCTAssertTrue(rec.isCritical)
+        rec.currentCount = 4
+        XCTAssertFalse(rec.isCritical)
+    }
+
+    func testLowStockMedicationsReflectsThreshold() {
+        let store = makeStore()
+        // med-4 (Magnesium) seeded at 3 with threshold 7 -> low.
+        XCTAssertTrue(store.lowStockMedications.contains { $0.id == "med-4" })
+        // med-3 (Vitamin D3) seeded at 90 with threshold 14 -> not low.
+        XCTAssertFalse(store.lowStockMedications.contains { $0.id == "med-3" })
+    }
+
+    func testSetInventoryCountClampsAtZero() {
+        let store = makeStore()
+        store.setInventoryCount(-5, for: "med-1")
+        XCTAssertEqual(store.inventory(for: "med-1")?.currentCount, 0)
+    }
+
+    func testAdjustInventoryDelta() {
+        let store = makeStore()
+        let before = store.inventory(for: "med-2")?.currentCount ?? 0
+        store.adjustInventory(by: -1, for: "med-2")
+        XCTAssertEqual(store.inventory(for: "med-2")?.currentCount, before - 1)
+    }
+
+    func testCrossingThresholdTogglesLowStock() {
+        let store = makeStore()
+        // med-1 starts at 22 (threshold 7) -> not low.
+        XCTAssertFalse(store.lowStockMedications.contains { $0.id == "med-1" })
+        store.setInventoryCount(5, for: "med-1")
+        XCTAssertTrue(store.lowStockMedications.contains { $0.id == "med-1" })
+    }
+}

--- a/ios/medication-list/PildoraMedicationList/Tests/PildoraMedicationListTests/JSONExportTests.swift
+++ b/ios/medication-list/PildoraMedicationList/Tests/PildoraMedicationListTests/JSONExportTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+@testable import PildoraMedicationList
+
+@MainActor
+final class JSONExportTests: XCTestCase {
+
+    private func makeStore() -> MedicationStore { .sample() }
+
+    func testDocumentIncludesAllMedicationsSortedByName() {
+        let store = makeStore()
+        let doc = DataExporter.document(from: store)
+        XCTAssertEqual(doc.medications.count, store.medications.count)
+        let names = doc.medications.map(\.medication.name)
+        XCTAssertEqual(names, names.sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending })
+    }
+
+    func testMetaCarriesDisclaimerAndSchemaVersion() {
+        let store = makeStore()
+        let doc = DataExporter.document(from: store)
+        XCTAssertEqual(doc.meta.schemaVersion, DataExporter.schemaVersion)
+        XCTAssertEqual(doc.meta.disclaimer, DrugReference.disclaimer)
+        XCTAssertEqual(doc.meta.app, "Pildora")
+    }
+
+    func testEntryBundlesInventoryAndReference() {
+        let store = makeStore()
+        let doc = DataExporter.document(from: store)
+        let metformin = doc.medications.first { $0.medication.id == "med-2" }
+        XCTAssertNotNil(metformin?.inventory)
+        XCTAssertEqual(metformin?.reference?.source, "openFDA")
+    }
+
+    func testJSONRoundTrips() throws {
+        let store = makeStore()
+        let doc = DataExporter.document(from: store)
+        let data = try DataExporter.jsonData(for: doc)
+        XCTAssertFalse(data.isEmpty)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(ExportDocument.self, from: data)
+        XCTAssertEqual(decoded.medications.count, doc.medications.count)
+        XCTAssertEqual(decoded.meta.disclaimer, doc.meta.disclaimer)
+    }
+
+    func testSuggestedFilename() {
+        let name = DataExporter.suggestedFilename(ext: "json")
+        XCTAssertTrue(name.hasPrefix("pildora-export-"))
+        XCTAssertTrue(name.hasSuffix(".json"))
+    }
+
+    func testDoctorReportContainsDisclaimerAndMedications() {
+        let store = makeStore()
+        let report = DoctorReport.build(from: store)
+        let text = report.plainText
+        XCTAssertTrue(text.contains(DrugReference.disclaimer))
+        XCTAssertTrue(text.contains("Metformin"))
+        // Rendered bytes are always produced (PDF on iOS, text fallback elsewhere).
+        XCTAssertFalse(PDFReportRenderer.render(report).isEmpty)
+    }
+}

--- a/ios/medication-list/PildoraMedicationList/Tests/PildoraMedicationListTests/RefillSchedulingTests.swift
+++ b/ios/medication-list/PildoraMedicationList/Tests/PildoraMedicationListTests/RefillSchedulingTests.swift
@@ -1,0 +1,65 @@
+import XCTest
+@testable import PildoraMedicationList
+
+@MainActor
+final class RefillSchedulingTests: XCTestCase {
+
+    func testReminderScheduledWhenStockDropsLow() {
+        let notifier = SimulatedRefillNotifier()
+        let store = MedicationStore(
+            medications: SampleData.medications,
+            inventory: SampleData.inventory(),
+            references: SampleData.drugReferences(),
+            notifier: notifier
+        )
+        store.setInventoryCount(2, for: "med-1") // threshold 7 -> low
+        XCTAssertNotNil(notifier.pending["med-1"])
+        XCTAssertEqual(notifier.pending["med-1"]?.remainingCount, 2)
+    }
+
+    func testReminderCancelledWhenRestocked() {
+        let notifier = SimulatedRefillNotifier()
+        let store = MedicationStore(
+            medications: SampleData.medications,
+            inventory: SampleData.inventory(),
+            references: SampleData.drugReferences(),
+            notifier: notifier
+        )
+        store.setInventoryCount(2, for: "med-1")
+        XCTAssertNotNil(notifier.pending["med-1"])
+        store.recordRefill(newCount: 60, for: "med-1")
+        XCTAssertNil(notifier.pending["med-1"])
+    }
+
+    func testNoReminderWhenAppWideRemindersDisabled() {
+        let notifier = SimulatedRefillNotifier()
+        let store = MedicationStore(
+            medications: SampleData.medications,
+            inventory: SampleData.inventory(),
+            references: SampleData.drugReferences(),
+            settings: AppSettings(refillRemindersEnabled: false),
+            notifier: notifier
+        )
+        store.setInventoryCount(1, for: "med-1")
+        XCTAssertNil(notifier.pending["med-1"])
+    }
+
+    func testPerMedicationReminderToggleRespected() {
+        let notifier = SimulatedRefillNotifier()
+        let store = MedicationStore(
+            medications: SampleData.medications,
+            inventory: SampleData.inventory(),
+            references: SampleData.drugReferences(),
+            notifier: notifier
+        )
+        store.setRefillReminderEnabled(false, for: "med-4") // med-4 is low
+        XCTAssertNil(notifier.pending["med-4"])
+    }
+
+    func testReminderBodyPluralization() {
+        let one = RefillReminder(medicationID: "x", medicationName: "Med", remainingCount: 1, unitNoun: "tablet")
+        XCTAssertTrue(one.body.contains("1 tablet "))
+        let many = RefillReminder(medicationID: "x", medicationName: "Med", remainingCount: 3, unitNoun: "tablet")
+        XCTAssertTrue(many.body.contains("3 tablets"))
+    }
+}

--- a/ios/medication-list/PildoraMedicationList/Tests/PildoraMedicationListTests/SearchFilterTests.swift
+++ b/ios/medication-list/PildoraMedicationList/Tests/PildoraMedicationListTests/SearchFilterTests.swift
@@ -1,0 +1,39 @@
+import XCTest
+@testable import PildoraMedicationList
+
+final class SearchFilterTests: XCTestCase {
+    private let meds = SampleData.medications
+
+    func testEmptyQueryReturnsAll() {
+        XCTAssertEqual(MedicationStore.filter(meds, query: "").count, meds.count)
+        XCTAssertEqual(MedicationStore.filter(meds, query: "   ").count, meds.count)
+    }
+
+    func testMatchesByNameCaseInsensitively() {
+        let results = MedicationStore.filter(meds, query: "metf")
+        XCTAssertEqual(results.map(\.name), ["Metformin"])
+    }
+
+    func testMatchesByGenericName() {
+        // "metformin hydrochloride" is the generic name on Metformin.
+        let results = MedicationStore.filter(meds, query: "hydrochloride")
+        XCTAssertEqual(results.map(\.name), ["Metformin"])
+    }
+
+    func testNoMatchesReturnsEmpty() {
+        XCTAssertTrue(MedicationStore.filter(meds, query: "zzzznotamed").isEmpty)
+    }
+
+    func testGroupingOrdersByCategoryThenName() {
+        let sections = MedicationStore.group(meds)
+        // Prescription should sort before supplement/vitamin/OTC by sortOrder.
+        XCTAssertEqual(sections.first?.category, .prescription)
+        // Categories are unique across sections.
+        XCTAssertEqual(Set(sections.map(\.category)).count, sections.count)
+        // Medications within a section are alphabetized.
+        for section in sections {
+            let names = section.medications.map(\.name)
+            XCTAssertEqual(names, names.sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending })
+        }
+    }
+}


### PR DESCRIPTION
## Description

Implements the Phase 1 (S13) medication management surface for iOS as a self-contained, buildable SwiftUI package at `ios/medication-list/PildoraMedicationList/`.

Because this issue's dependencies are still open (#43 design system, #44 SQLCipher data layer, #48 CRUD) and there is no app skeleton yet, the feature is built against an in-memory sample store with a minimal local design-token subset. The store and notification scheduler are protocol-/`ObservableObject`-backed so the real persistence, CRUD, and design system can be swapped in later without changing the views. It builds and tests on the macOS toolchain (same bar as the existing `ios/` spikes) and also builds for an iOS simulator destination.

### What's included

- **Medication list** — scrollable, category-grouped list with search/filter by name (and generic name), low-stock indicators, and empty/no-results states (`MedicationListView`, `MedicationRow`).
- **Drug reference display** — drug class, common side effects, **source + date attribution**, and the required informational-only disclaimer (`DrugReferenceSection`, `DrugReference`).
- **Manual inventory tracking** — per-medication count, user-configurable refill threshold, low/critical alerts, and record-refill (`InventoryEditorView`, `MedicationStore`).
- **Refill reminders** — **local notifications only**, protocol-backed (`UNUserNotificationCenter` on iOS, simulated elsewhere), so the server never learns dose/refill timing.
- **Profile & settings** — overview, default threshold, app-wide reminder toggle, appearance (`ProfileView`, `SettingsView`).
- **Data export** — full decrypted **JSON** and on-device **Doctor Mode PDF**, shared via `ShareLink` with no server involvement (`DataExporter`, `PDFReportRenderer`, `ExportView`).
- **Accessibility** — VoiceOver labels/hints, Dynamic Type to xxxLarge, dark mode, status conveyed by text+icon (never color alone), and a preview catalog.
- **Tests** — 21 unit tests covering search/filter, inventory thresholds, refill scheduling, and JSON/PDF export.

## Related Issues

Closes #50

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Component

- [ ] `crypto/` — Encryption library
- [x] `ios/` — Apple platform apps
- [ ] `web/` — Web app
- [ ] `cli/` — CLI tool
- [ ] `server/` — Sync server
- [ ] `data/` — Drug data pipeline
- [ ] `docs/` — Documentation

## Privacy Checklist

- [x] No plaintext user health data is sent to or stored on the server
- [x] No new metadata exposure introduced (or documented if unavoidable)
- [x] Drug/health features include appropriate disclaimers and source attribution
- [x] Any new external service interaction is documented in the trust boundary model

Notes: refill reminders are local notifications only; JSON/PDF export is generated entirely on-device. No new server or external service interaction is introduced. Every drug reference datum shows its source + date and carries the informational-only disclaimer.

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] Tests pass (if applicable) — `swift test` (21 passing) on macOS; `swift build` and iOS simulator build both succeed; markdownlint clean
- [x] I have updated documentation (if applicable) — package `README.md`, `ios/README.md`, and `CHANGELOG.md`
