### PR TITLE
feat: add iOS Today view and dose confirmation package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- iOS Today view feature (`ios/today-view/`): chronological dose sections (morning/afternoon/evening/bedtime), dose states (upcoming/due now/overdue/taken/skipped/snoozed), one-tap confirmation with haptic feedback, swipe actions (taken/skip/snooze), PRN quick logging, and VoiceOver/Dynamic Type support.
 - iOS medication list feature (`ios/medication-list/`): SwiftUI package with a searchable, category-grouped medication list, drug reference display (class, side effects, source + date attribution, informational-only disclaimer), manual inventory tracking with user-configurable low-stock thresholds and local refill reminders, a profile/settings screen, and on-device data export (decrypted JSON + Doctor Mode PDF). Self-contained against an in-memory sample store pending the data layer (#44), CRUD (#48), and design system (#43).
 - `pildora-crypto-ffi` crate: UniFFI bindings exposing `pildora-crypto` to Swift via FFI (ADR-007)
 - iOS FFI spike: prototype Swift app validating Rust → Swift FFI bridge with encrypt/decrypt roundtrip and benchmarks

--- a/ios/README.md
+++ b/ios/README.md
@@ -47,5 +47,6 @@ standalone SwiftUI package:
 - **Notification rotation** ([`notification-spike/`](notification-spike/), issue #23) — 64-limit rotation strategy with priority-based scheduling
 - **Accessibility baseline** ([`accessibility-spike/`](accessibility-spike/), issue #24) — SwiftUI + VoiceOver + Dynamic Type prototype
 - **Medication list + inventory** ([`medication-list/`](medication-list/PildoraMedicationList/), issue #50) — medication list with search, drug reference display, manual inventory tracking with low-stock / refill reminders, and profile + JSON/PDF export. Self-contained against an in-memory sample store until the data layer (#44), CRUD (#48), and design system (#43) land.
+- **Today view + dose confirmation** ([`today-view/`](today-view/PildoraTodayView/), issue #47) — chronological Today timeline with one-tap dose confirmation, swipe actions (taken/skip/snooze), PRN quick logging, and VoiceOver/Dynamic Type support. Self-contained against an in-memory sample store until schedule engine and persistence wiring land.
 
 Requires completion of `pildora-crypto` (Phase 0) before app development begins.

--- a/ios/today-view/PildoraTodayView/Package.swift
+++ b/ios/today-view/PildoraTodayView/Package.swift
@@ -1,0 +1,27 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "PildoraTodayView",
+    platforms: [
+        .macOS(.v14),
+        .iOS(.v17),
+    ],
+    products: [
+        .library(
+            name: "PildoraTodayView",
+            targets: ["PildoraTodayView"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "PildoraTodayView",
+            path: "Sources/PildoraTodayView"
+        ),
+        .testTarget(
+            name: "PildoraTodayViewTests",
+            dependencies: ["PildoraTodayView"],
+            path: "Tests/PildoraTodayViewTests"
+        ),
+    ]
+)

--- a/ios/today-view/PildoraTodayView/README.md
+++ b/ios/today-view/PildoraTodayView/README.md
@@ -1,0 +1,43 @@
+# PildoraTodayView
+
+SwiftUI feature package for **issue #47** — the Phase 1 (S13) Today surface:
+chronological dose timeline, one-tap confirmation, swipe actions (taken/skip/snooze),
+PRN quick logging, and accessibility-first UI behavior.
+
+## Status
+
+🚧 Self-contained feature slice. Like other iOS feature slices, this package runs
+against an in-memory sample store until shared dependencies land:
+
+- schedule engine wiring
+- medication CRUD/data layer (#44/#48)
+- full design system foundation (#43)
+
+The store and view model shapes are intentionally structured so encrypted SQLCipher
+persistence can replace sample data without changing view contracts.
+
+## Build & test
+
+```sh
+cd ios/today-view/PildoraTodayView
+swift build
+swift test
+```
+
+Builds on macOS toolchain. iOS-only integrations (haptics) are guarded with
+`#if canImport(UIKit)` and no-op on macOS.
+
+## Scope notes
+
+- Dose states covered: upcoming, due now, overdue, taken, skipped, snoozed.
+- Dose actions covered: one-tap taken, swipe skip, swipe snooze (+15m default).
+- PRN medications are log-only quick actions (no auto scheduling).
+- Empty state appears when all scheduled doses for today are resolved.
+
+## Privacy / compliance notes
+
+- **Zero-knowledge / local-first:** this package uses only local in-memory state.
+- **No medical advice:** this surface tracks dose actions; it does not provide
+  recommendations, diagnostics, or dosing guidance.
+- **Multi-vault readiness:** user-health entities include `vaultId` to preserve
+  one-vault-per-encryption-boundary modeling.

--- a/ios/today-view/PildoraTodayView/Sources/PildoraTodayView/Models/TodayModels.swift
+++ b/ios/today-view/PildoraTodayView/Sources/PildoraTodayView/Models/TodayModels.swift
@@ -1,0 +1,168 @@
+import Foundation
+
+public enum DoseTimeWindow: String, CaseIterable, Codable, Sendable {
+    case morning
+    case afternoon
+    case evening
+    case bedtime
+
+    public var displayName: String {
+        switch self {
+        case .morning: return "Morning"
+        case .afternoon: return "Afternoon"
+        case .evening: return "Evening"
+        case .bedtime: return "Bedtime"
+        }
+    }
+
+    public var sortOrder: Int {
+        switch self {
+        case .morning: return 0
+        case .afternoon: return 1
+        case .evening: return 2
+        case .bedtime: return 3
+        }
+    }
+
+    public static func window(for date: Date, calendar: Calendar = .current) -> DoseTimeWindow {
+        let hour = calendar.component(.hour, from: date)
+        switch hour {
+        case 5...11: return .morning
+        case 12...16: return .afternoon
+        case 17...20: return .evening
+        default: return .bedtime
+        }
+    }
+}
+
+public enum DoseState: String, CaseIterable, Codable, Sendable {
+    case upcoming
+    case dueNow
+    case overdue
+    case taken
+    case skipped
+    case snoozed
+
+    public var displayText: String {
+        switch self {
+        case .upcoming: return "Upcoming"
+        case .dueNow: return "Due now"
+        case .overdue: return "Overdue"
+        case .taken: return "Taken"
+        case .skipped: return "Skipped"
+        case .snoozed: return "Snoozed"
+        }
+    }
+}
+
+public struct ScheduledDose: Identifiable, Codable, Hashable, Sendable {
+    public var id: String
+    public var vaultId: String
+    public var medicationID: String
+    public var medicationName: String
+    public var dosage: String
+    public var scheduledAt: Date
+
+    public init(
+        id: String = UUID().uuidString,
+        vaultId: String,
+        medicationID: String,
+        medicationName: String,
+        dosage: String,
+        scheduledAt: Date
+    ) {
+        self.id = id
+        self.vaultId = vaultId
+        self.medicationID = medicationID
+        self.medicationName = medicationName
+        self.dosage = dosage
+        self.scheduledAt = scheduledAt
+    }
+}
+
+public struct PRNMedication: Identifiable, Codable, Hashable, Sendable {
+    public var id: String
+    public var vaultId: String
+    public var medicationName: String
+    public var dosage: String
+
+    public init(
+        id: String = UUID().uuidString,
+        vaultId: String,
+        medicationName: String,
+        dosage: String
+    ) {
+        self.id = id
+        self.vaultId = vaultId
+        self.medicationName = medicationName
+        self.dosage = dosage
+    }
+}
+
+public struct DoseLogEntry: Identifiable, Codable, Hashable, Sendable {
+    public var id: String
+    public var vaultId: String
+    public var medicationID: String
+    public var medicationName: String
+    public var dosage: String
+    public var scheduledDoseID: String?
+    public var status: DoseState
+    public var recordedAt: Date
+    public var scheduledFor: Date?
+    public var snoozedUntil: Date?
+    public var note: String?
+
+    public var isPRN: Bool { scheduledDoseID == nil }
+
+    public init(
+        id: String = UUID().uuidString,
+        vaultId: String,
+        medicationID: String,
+        medicationName: String,
+        dosage: String,
+        scheduledDoseID: String?,
+        status: DoseState,
+        recordedAt: Date,
+        scheduledFor: Date?,
+        snoozedUntil: Date? = nil,
+        note: String? = nil
+    ) {
+        self.id = id
+        self.vaultId = vaultId
+        self.medicationID = medicationID
+        self.medicationName = medicationName
+        self.dosage = dosage
+        self.scheduledDoseID = scheduledDoseID
+        self.status = status
+        self.recordedAt = recordedAt
+        self.scheduledFor = scheduledFor
+        self.snoozedUntil = snoozedUntil
+        self.note = note
+    }
+}
+
+public struct TodayDoseItem: Identifiable, Hashable, Sendable {
+    public let dose: ScheduledDose
+    public let state: DoseState
+    public let log: DoseLogEntry?
+
+    public init(dose: ScheduledDose, state: DoseState, log: DoseLogEntry?) {
+        self.dose = dose
+        self.state = state
+        self.log = log
+    }
+
+    public var id: String { dose.id }
+}
+
+public struct TodaySection: Identifiable, Hashable, Sendable {
+    public let window: DoseTimeWindow
+    public let doses: [TodayDoseItem]
+
+    public init(window: DoseTimeWindow, doses: [TodayDoseItem]) {
+        self.window = window
+        self.doses = doses
+    }
+
+    public var id: DoseTimeWindow { window }
+}

--- a/ios/today-view/PildoraTodayView/Sources/PildoraTodayView/Store/SampleData.swift
+++ b/ios/today-view/PildoraTodayView/Sources/PildoraTodayView/Store/SampleData.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+public enum TodaySampleData {
+    public static let vaultId = "vault-default"
+
+    public static func scheduledDoses(
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) -> [ScheduledDose] {
+        let dayStart = calendar.startOfDay(for: now)
+        func at(_ hour: Int, _ minute: Int = 0) -> Date {
+            calendar.date(bySettingHour: hour, minute: minute, second: 0, of: dayStart) ?? dayStart
+        }
+
+        return [
+            ScheduledDose(id: "dose-omeprazole-am", vaultId: vaultId, medicationID: "med-omeprazole", medicationName: "Omeprazole", dosage: "20 mg", scheduledAt: at(6, 30)),
+            ScheduledDose(id: "dose-levothyroxine-am", vaultId: vaultId, medicationID: "med-levothyroxine", medicationName: "Levothyroxine", dosage: "88 mcg", scheduledAt: at(7, 0)),
+            ScheduledDose(id: "dose-probiotic-am", vaultId: vaultId, medicationID: "med-probiotic", medicationName: "Probiotic Blend", dosage: "1 capsule", scheduledAt: at(7, 30)),
+            ScheduledDose(id: "dose-metformin-am", vaultId: vaultId, medicationID: "med-metformin", medicationName: "Metformin", dosage: "500 mg", scheduledAt: at(8, 0)),
+            ScheduledDose(id: "dose-aspirin-am", vaultId: vaultId, medicationID: "med-aspirin", medicationName: "Aspirin", dosage: "81 mg", scheduledAt: at(8, 30)),
+            ScheduledDose(id: "dose-b12-am", vaultId: vaultId, medicationID: "med-b12", medicationName: "Vitamin B12", dosage: "1,000 mcg", scheduledAt: at(9, 30)),
+            ScheduledDose(id: "dose-vitamin-d-noon", vaultId: vaultId, medicationID: "med-vitamin-d", medicationName: "Cholecalciferol (Vitamin D3)", dosage: "5,000 IU", scheduledAt: at(12, 30)),
+            ScheduledDose(id: "dose-gabapentin-noon", vaultId: vaultId, medicationID: "med-gabapentin", medicationName: "Gabapentin", dosage: "300 mg", scheduledAt: at(14, 0)),
+            ScheduledDose(id: "dose-omega3-afternoon", vaultId: vaultId, medicationID: "med-omega3", medicationName: "Omega-3 Fish Oil", dosage: "1 capsule", scheduledAt: at(15, 30)),
+            ScheduledDose(id: "dose-calcium-evening", vaultId: vaultId, medicationID: "med-calcium", medicationName: "Calcium Citrate", dosage: "600 mg", scheduledAt: at(18, 0)),
+            ScheduledDose(id: "dose-magnesium-evening", vaultId: vaultId, medicationID: "med-magnesium", medicationName: "Magnesium Glycinate", dosage: "400 mg", scheduledAt: at(19, 30)),
+            ScheduledDose(id: "dose-atorvastatin-evening", vaultId: vaultId, medicationID: "med-atorvastatin", medicationName: "Atorvastatin", dosage: "20 mg", scheduledAt: at(20, 0)),
+            ScheduledDose(id: "dose-gabapentin-evening", vaultId: vaultId, medicationID: "med-gabapentin", medicationName: "Gabapentin", dosage: "300 mg", scheduledAt: at(21, 0)),
+            ScheduledDose(id: "dose-cetirizine-bedtime", vaultId: vaultId, medicationID: "med-cetirizine", medicationName: "Cetirizine", dosage: "10 mg", scheduledAt: at(22, 0)),
+            ScheduledDose(id: "dose-melatonin-bedtime", vaultId: vaultId, medicationID: "med-melatonin", medicationName: "Melatonin", dosage: "3 mg", scheduledAt: at(22, 30)),
+            ScheduledDose(id: "dose-metformin-bedtime", vaultId: vaultId, medicationID: "med-metformin", medicationName: "Metformin", dosage: "500 mg", scheduledAt: at(23, 0)),
+        ]
+    }
+
+    public static func prnMedications() -> [PRNMedication] {
+        [
+            PRNMedication(id: "prn-ibuprofen", vaultId: vaultId, medicationName: "Ibuprofen", dosage: "200 mg"),
+            PRNMedication(id: "prn-albuterol", vaultId: vaultId, medicationName: "Albuterol inhaler", dosage: "2 puffs"),
+        ]
+    }
+
+    public static func seedLogs(
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) -> [DoseLogEntry] {
+        let byID = Dictionary(
+            uniqueKeysWithValues: scheduledDoses(now: now, calendar: calendar).map { ($0.id, $0) }
+        )
+        guard
+            let metforminAM = byID["dose-metformin-am"],
+            let levothyroxineAM = byID["dose-levothyroxine-am"],
+            let gabapentinNoon = byID["dose-gabapentin-noon"]
+        else {
+            return []
+        }
+
+        let skipTime = calendar.date(byAdding: .minute, value: 10, to: levothyroxineAM.scheduledAt) ?? levothyroxineAM.scheduledAt
+        let takenTime = calendar.date(byAdding: .minute, value: 5, to: metforminAM.scheduledAt) ?? metforminAM.scheduledAt
+        let snoozeTime = calendar.date(byAdding: .minute, value: -5, to: now) ?? now
+        let snoozedUntil = calendar.date(byAdding: .minute, value: 15, to: now) ?? now
+
+        return [
+            DoseLogEntry(
+                id: "log-metformin-am-taken",
+                vaultId: vaultId,
+                medicationID: metforminAM.medicationID,
+                medicationName: metforminAM.medicationName,
+                dosage: metforminAM.dosage,
+                scheduledDoseID: metforminAM.id,
+                status: .taken,
+                recordedAt: takenTime,
+                scheduledFor: metforminAM.scheduledAt
+            ),
+            DoseLogEntry(
+                id: "log-levothyroxine-am-skipped",
+                vaultId: vaultId,
+                medicationID: levothyroxineAM.medicationID,
+                medicationName: levothyroxineAM.medicationName,
+                dosage: levothyroxineAM.dosage,
+                scheduledDoseID: levothyroxineAM.id,
+                status: .skipped,
+                recordedAt: skipTime,
+                scheduledFor: levothyroxineAM.scheduledAt,
+                note: "Missed fasting window"
+            ),
+            DoseLogEntry(
+                id: "log-gabapentin-noon-snoozed",
+                vaultId: vaultId,
+                medicationID: gabapentinNoon.medicationID,
+                medicationName: gabapentinNoon.medicationName,
+                dosage: gabapentinNoon.dosage,
+                scheduledDoseID: gabapentinNoon.id,
+                status: .snoozed,
+                recordedAt: snoozeTime,
+                scheduledFor: gabapentinNoon.scheduledAt,
+                snoozedUntil: snoozedUntil
+            ),
+        ]
+    }
+}

--- a/ios/today-view/PildoraTodayView/Sources/PildoraTodayView/Store/TodayStore.swift
+++ b/ios/today-view/PildoraTodayView/Sources/PildoraTodayView/Store/TodayStore.swift
@@ -1,0 +1,207 @@
+import Foundation
+import Combine
+
+@MainActor
+public final class TodayStore: ObservableObject {
+    @Published public private(set) var scheduledDoses: [ScheduledDose]
+    @Published public private(set) var prnMedications: [PRNMedication]
+    @Published public private(set) var doseLogs: [DoseLogEntry]
+    @Published public var now: Date
+
+    private let calendar: Calendar
+
+    public init(
+        scheduledDoses: [ScheduledDose],
+        prnMedications: [PRNMedication],
+        doseLogs: [DoseLogEntry] = [],
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) {
+        self.scheduledDoses = scheduledDoses
+        self.prnMedications = prnMedications
+        self.doseLogs = doseLogs
+        self.now = now
+        self.calendar = calendar
+    }
+
+    public static func sample(now: Date = Date(), calendar: Calendar = .current) -> TodayStore {
+        TodayStore(
+            scheduledDoses: TodaySampleData.scheduledDoses(now: now, calendar: calendar),
+            prnMedications: TodaySampleData.prnMedications(),
+            doseLogs: TodaySampleData.seedLogs(now: now, calendar: calendar),
+            now: now,
+            calendar: calendar
+        )
+    }
+
+    public func advanceClock(to date: Date) {
+        now = date
+    }
+
+    public var doseItems: [TodayDoseItem] {
+        scheduledDoses
+            .sorted { $0.scheduledAt < $1.scheduledAt }
+            .map { dose in
+                let resolved = resolveState(for: dose, at: now)
+                return TodayDoseItem(dose: dose, state: resolved.state, log: resolved.log)
+            }
+    }
+
+    public var sections: [TodaySection] {
+        let grouped = Dictionary(grouping: doseItems) {
+            DoseTimeWindow.window(for: $0.dose.scheduledAt, calendar: calendar)
+        }
+        return grouped
+            .map { window, doses in
+                TodaySection(window: window, doses: doses.sorted { $0.dose.scheduledAt < $1.dose.scheduledAt })
+            }
+            .sorted { $0.window.sortOrder < $1.window.sortOrder }
+    }
+
+    public var hasScheduledDoses: Bool {
+        !scheduledDoses.isEmpty
+    }
+
+    public var allScheduledDosesResolved: Bool {
+        !scheduledDoses.isEmpty
+            && doseItems.allSatisfy { item in
+                item.state == .taken || item.state == .skipped
+            }
+    }
+
+    public var prnHistoryToday: [DoseLogEntry] {
+        doseLogs
+            .filter { $0.isPRN && calendar.isDate($0.recordedAt, inSameDayAs: now) }
+            .sorted { $0.recordedAt > $1.recordedAt }
+    }
+
+    public func markTaken(doseID: String, at date: Date = Date()) {
+        guard let dose = scheduledDoses.first(where: { $0.id == doseID }) else {
+            assertionFailure("Attempted to mark unknown dose '\(doseID)' as taken.")
+            return
+        }
+        now = date
+        upsertScheduledLog(
+            for: dose,
+            status: .taken,
+            recordedAt: date
+        )
+    }
+
+    public func skipDose(doseID: String, reason: String? = nil, at date: Date = Date()) {
+        guard let dose = scheduledDoses.first(where: { $0.id == doseID }) else {
+            assertionFailure("Attempted to skip unknown dose '\(doseID)'.")
+            return
+        }
+        now = date
+        upsertScheduledLog(
+            for: dose,
+            status: .skipped,
+            recordedAt: date,
+            note: reason
+        )
+    }
+
+    public func snoozeDose(doseID: String, minutes: Int = 15, at date: Date = Date()) {
+        guard let dose = scheduledDoses.first(where: { $0.id == doseID }) else {
+            assertionFailure("Attempted to snooze unknown dose '\(doseID)'.")
+            return
+        }
+        now = date
+        let clampedMinutes = max(1, minutes)
+        let until = calendar.date(byAdding: .minute, value: clampedMinutes, to: date) ?? date
+        upsertScheduledLog(
+            for: dose,
+            status: .snoozed,
+            recordedAt: date,
+            snoozedUntil: until,
+            note: "Snoozed \(clampedMinutes) min"
+        )
+    }
+
+    public func logPRN(medicationID: String, at date: Date = Date()) {
+        guard let med = prnMedications.first(where: { $0.id == medicationID }) else {
+            assertionFailure("Attempted to log unknown PRN medication '\(medicationID)'.")
+            return
+        }
+        now = date
+        let entry = DoseLogEntry(
+            vaultId: med.vaultId,
+            medicationID: med.id,
+            medicationName: med.medicationName,
+            dosage: med.dosage,
+            scheduledDoseID: nil,
+            status: .taken,
+            recordedAt: date,
+            scheduledFor: nil,
+            note: "PRN quick log"
+        )
+        doseLogs.append(entry)
+        doseLogs.sort { $0.recordedAt > $1.recordedAt }
+    }
+
+    public func formattedTime(_ date: Date) -> String {
+        Self.timeFormatter.string(from: date)
+    }
+
+    private func resolveState(for dose: ScheduledDose, at now: Date) -> (state: DoseState, log: DoseLogEntry?) {
+        if let log = latestLog(forDoseID: dose.id) {
+            switch log.status {
+            case .taken, .skipped:
+                return (log.status, log)
+            case .snoozed:
+                if let snoozedUntil = log.snoozedUntil, now >= snoozedUntil {
+                    return (.dueNow, log)
+                }
+                return (.snoozed, log)
+            case .upcoming, .dueNow, .overdue:
+                break
+            }
+        }
+
+        let delta = dose.scheduledAt.timeIntervalSince(now)
+        if delta > 15 * 60 {
+            return (.upcoming, nil)
+        }
+        if delta >= -30 * 60 {
+            return (.dueNow, nil)
+        }
+        return (.overdue, nil)
+    }
+
+    private func latestLog(forDoseID doseID: String) -> DoseLogEntry? {
+        doseLogs
+            .filter { $0.scheduledDoseID == doseID }
+            .max { $0.recordedAt < $1.recordedAt }
+    }
+
+    private func upsertScheduledLog(
+        for dose: ScheduledDose,
+        status: DoseState,
+        recordedAt: Date,
+        snoozedUntil: Date? = nil,
+        note: String? = nil
+    ) {
+        doseLogs.removeAll { $0.scheduledDoseID == dose.id }
+        let entry = DoseLogEntry(
+            vaultId: dose.vaultId,
+            medicationID: dose.medicationID,
+            medicationName: dose.medicationName,
+            dosage: dose.dosage,
+            scheduledDoseID: dose.id,
+            status: status,
+            recordedAt: recordedAt,
+            scheduledFor: dose.scheduledAt,
+            snoozedUntil: snoozedUntil,
+            note: note
+        )
+        doseLogs.append(entry)
+        doseLogs.sort { $0.recordedAt > $1.recordedAt }
+    }
+
+    private static let timeFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.timeStyle = .short
+        return formatter
+    }()
+}

--- a/ios/today-view/PildoraTodayView/Sources/PildoraTodayView/Views/DoseRow.swift
+++ b/ios/today-view/PildoraTodayView/Sources/PildoraTodayView/Views/DoseRow.swift
@@ -1,0 +1,83 @@
+import SwiftUI
+
+struct DoseRow: View {
+    let item: TodayDoseItem
+    let timeText: String
+    let onMarkTaken: () -> Void
+
+    @ScaledMetric(relativeTo: .body) private var confirmationButtonMinHeight: CGFloat = 44
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    Text(item.dose.medicationName)
+                        .font(.headline)
+                        .foregroundStyle(titleColor)
+                        .lineLimit(nil)
+                        .fixedSize(horizontal: false, vertical: true)
+                    Spacer(minLength: 8)
+                    Text(timeText)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+
+                Text(item.dose.dosage)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+
+                HStack(spacing: 8) {
+                    DoseStatusBadge(state: item.state)
+                    if item.state == .snoozed, let until = item.log?.snoozedUntil {
+                        Text("until \(Self.timeFormatter.string(from: until))")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    } else if item.state == .skipped, let note = item.log?.note, !note.isEmpty {
+                        Text(note)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                }
+            }
+
+            if isActionable {
+                Button("Taken", action: onMarkTaken)
+                    .buttonStyle(.borderedProminent)
+                    .tint(.green)
+                    .controlSize(.small)
+                    .frame(minHeight: confirmationButtonMinHeight)
+                    .accessibilityLabel(
+                        "Mark \(item.dose.medicationName) \(item.dose.dosage) as taken"
+                    )
+                    .accessibilityHint("Logs this dose as taken")
+            }
+        }
+        .padding(.vertical, 4)
+        .frame(minHeight: 44)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(accessibilitySummary)
+    }
+
+    private var isActionable: Bool {
+        item.state != .taken && item.state != .skipped
+    }
+
+    private var accessibilitySummary: String {
+        "\(item.dose.medicationName), \(item.dose.dosage), \(timeText), \(item.state.displayText)"
+    }
+
+    private var titleColor: Color {
+        switch item.state {
+        case .dueNow: return .orange
+        case .overdue: return .red
+        default: return .primary
+        }
+    }
+
+    private static let timeFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.timeStyle = .short
+        return formatter
+    }()
+}

--- a/ios/today-view/PildoraTodayView/Sources/PildoraTodayView/Views/DoseStatusBadge.swift
+++ b/ios/today-view/PildoraTodayView/Sources/PildoraTodayView/Views/DoseStatusBadge.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+
+struct DoseStatusBadge: View {
+    let state: DoseState
+
+    var body: some View {
+        HStack(spacing: 4) {
+            Image(systemName: iconName)
+                .imageScale(.small)
+                .accessibilityHidden(true)
+            Text(state.displayText)
+                .font(.caption.weight(.semibold))
+        }
+        .foregroundStyle(color)
+        .accessibilityElement(children: .combine)
+    }
+
+    private var iconName: String {
+        switch state {
+        case .upcoming: return "clock"
+        case .dueNow: return "bell.fill"
+        case .overdue: return "exclamationmark.triangle.fill"
+        case .taken: return "checkmark.circle.fill"
+        case .skipped: return "forward.fill"
+        case .snoozed: return "zzz"
+        }
+    }
+
+    private var color: Color {
+        switch state {
+        case .upcoming: return .blue
+        case .dueNow: return .orange
+        case .overdue: return .red
+        case .taken: return .green
+        case .skipped: return .secondary
+        case .snoozed: return .indigo
+        }
+    }
+}

--- a/ios/today-view/PildoraTodayView/Sources/PildoraTodayView/Views/TodayView.swift
+++ b/ios/today-view/PildoraTodayView/Sources/PildoraTodayView/Views/TodayView.swift
@@ -1,0 +1,186 @@
+import SwiftUI
+#if canImport(UIKit)
+import UIKit
+#endif
+
+public struct TodayView: View {
+    @ObservedObject private var store: TodayStore
+
+    public init(store: TodayStore) {
+        self.store = store
+    }
+
+    public var body: some View {
+        NavigationStack {
+            Group {
+                if !store.hasScheduledDoses {
+                    noScheduleState
+                } else if store.allScheduledDosesResolved {
+                    allDoneState
+                } else {
+                    listContent
+                }
+            }
+            .navigationTitle("Today")
+        }
+    }
+
+    private var listContent: some View {
+        List {
+            prnSection
+
+            ForEach(store.sections) { section in
+                Section {
+                    ForEach(section.doses) { item in
+                        DoseRow(
+                            item: item,
+                            timeText: store.formattedTime(item.dose.scheduledAt),
+                            onMarkTaken: {
+                                markTaken(item)
+                            }
+                        )
+                        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+                            Button {
+                                markTaken(item)
+                            } label: {
+                                Label("Taken", systemImage: "checkmark.circle.fill")
+                            }
+                            .tint(.green)
+
+                            Button {
+                                skip(item)
+                            } label: {
+                                Label("Skip", systemImage: "forward.fill")
+                            }
+                            .tint(.orange)
+                        }
+                        .swipeActions(edge: .leading, allowsFullSwipe: false) {
+                            Button {
+                                snooze(item)
+                            } label: {
+                                Label("Snooze", systemImage: "zzz")
+                            }
+                            .tint(.indigo)
+                        }
+                    }
+                } header: {
+                    Text(section.window.displayName)
+                        .accessibilityAddTraits(.isHeader)
+                }
+            }
+        }
+        .platformListStyle()
+    }
+
+    private var prnSection: some View {
+        Section {
+            ForEach(store.prnMedications) { med in
+                HStack(spacing: 8) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(med.medicationName)
+                            .font(.subheadline.weight(.medium))
+                        Text("\(med.dosage) · As needed")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                    Button("Log") {
+                        logPRN(med.id)
+                    }
+                    .buttonStyle(.bordered)
+                    .accessibilityLabel("Log PRN dose for \(med.medicationName)")
+                }
+                .frame(minHeight: 44)
+            }
+
+            if let latestPRN = store.prnHistoryToday.first {
+                Text("Last PRN log: \(latestPRN.medicationName) at \(store.formattedTime(latestPRN.recordedAt))")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .accessibilityLabel(
+                        "Last PRN log \(latestPRN.medicationName) at \(store.formattedTime(latestPRN.recordedAt))"
+                    )
+            }
+        } header: {
+            Text("Quick log (PRN)")
+                .accessibilityAddTraits(.isHeader)
+        }
+    }
+
+    private var noScheduleState: some View {
+        ContentUnavailableView(
+            "No doses scheduled",
+            systemImage: "calendar.badge.clock",
+            description: Text("Add a medication schedule to see today’s timeline.")
+        )
+    }
+
+    private var allDoneState: some View {
+        ContentUnavailableView(
+            "All caught up",
+            systemImage: "checkmark.circle.fill",
+            description: Text("Great job — all scheduled doses for today are confirmed.")
+        )
+    }
+
+    private func markTaken(_ item: TodayDoseItem) {
+        store.markTaken(doseID: item.id)
+        triggerSuccessHaptic()
+    }
+
+    private func skip(_ item: TodayDoseItem) {
+        store.skipDose(doseID: item.id)
+        triggerSelectionHaptic()
+    }
+
+    private func snooze(_ item: TodayDoseItem) {
+        store.snoozeDose(doseID: item.id, minutes: 15)
+        triggerSelectionHaptic()
+    }
+
+    private func logPRN(_ medicationID: String) {
+        store.logPRN(medicationID: medicationID)
+        triggerSelectionHaptic()
+    }
+
+    private func triggerSuccessHaptic() {
+        #if canImport(UIKit)
+        let generator = UINotificationFeedbackGenerator()
+        generator.notificationOccurred(.success)
+        #endif
+    }
+
+    private func triggerSelectionHaptic() {
+        #if canImport(UIKit)
+        let generator = UIImpactFeedbackGenerator(style: .light)
+        generator.impactOccurred()
+        #endif
+    }
+}
+
+private extension View {
+    @ViewBuilder
+    func platformListStyle() -> some View {
+        #if os(iOS)
+        self.listStyle(.insetGrouped)
+        #else
+        self.listStyle(.automatic)
+        #endif
+    }
+}
+
+#if DEBUG
+#Preview("Today") {
+    TodayView(store: .sample())
+}
+
+#Preview("Today · xxxLarge") {
+    TodayView(store: .sample())
+        .environment(\.dynamicTypeSize, .xxxLarge)
+}
+
+#Preview("Today · Accessibility 3") {
+    TodayView(store: .sample())
+        .environment(\.dynamicTypeSize, .accessibility3)
+}
+#endif

--- a/ios/today-view/PildoraTodayView/Tests/PildoraTodayViewTests/TodayStoreTests.swift
+++ b/ios/today-view/PildoraTodayView/Tests/PildoraTodayViewTests/TodayStoreTests.swift
@@ -1,0 +1,144 @@
+import XCTest
+@testable import PildoraTodayView
+
+@MainActor
+final class TodayStoreTests: XCTestCase {
+    func testSectionsAreGroupedByWindowAndSortedChronologically() {
+        let calendar = makeUTCCalendar()
+        let now = makeDate(hour: 10, minute: 0, calendar: calendar)
+        let doses = [
+            makeDose(id: "morning-1", hour: 8, minute: 0, name: "A", calendar: calendar),
+            makeDose(id: "afternoon-1", hour: 13, minute: 0, name: "B", calendar: calendar),
+            makeDose(id: "evening-1", hour: 19, minute: 0, name: "C", calendar: calendar),
+            makeDose(id: "bedtime-1", hour: 22, minute: 0, name: "D", calendar: calendar),
+        ]
+
+        let store = TodayStore(
+            scheduledDoses: doses,
+            prnMedications: [],
+            now: now,
+            calendar: calendar
+        )
+
+        XCTAssertEqual(store.sections.map(\.window), [.morning, .afternoon, .evening, .bedtime])
+        XCTAssertEqual(store.sections.flatMap(\.doses).map(\.id), ["morning-1", "afternoon-1", "evening-1", "bedtime-1"])
+    }
+
+    func testStateClassificationForUpcomingDueAndOverdue() {
+        let calendar = makeUTCCalendar()
+        let now = makeDate(hour: 14, minute: 0, calendar: calendar)
+        let doses = [
+            makeDose(id: "overdue", hour: 12, minute: 0, name: "Overdue Med", calendar: calendar),
+            makeDose(id: "due-past", hour: 13, minute: 45, name: "Due Past Med", calendar: calendar),
+            makeDose(id: "due-future", hour: 14, minute: 10, name: "Due Future Med", calendar: calendar),
+            makeDose(id: "upcoming", hour: 16, minute: 0, name: "Upcoming Med", calendar: calendar),
+        ]
+
+        let store = TodayStore(
+            scheduledDoses: doses,
+            prnMedications: [],
+            now: now,
+            calendar: calendar
+        )
+
+        XCTAssertEqual(store.doseItems.first(where: { $0.id == "overdue" })?.state, .overdue)
+        XCTAssertEqual(store.doseItems.first(where: { $0.id == "due-past" })?.state, .dueNow)
+        XCTAssertEqual(store.doseItems.first(where: { $0.id == "due-future" })?.state, .dueNow)
+        XCTAssertEqual(store.doseItems.first(where: { $0.id == "upcoming" })?.state, .upcoming)
+    }
+
+    func testMarkTakenPersistsLogAndUpdatesState() {
+        let calendar = makeUTCCalendar()
+        let now = makeDate(hour: 9, minute: 0, calendar: calendar)
+        let dose = makeDose(id: "dose-1", hour: 9, minute: 5, name: "Metformin", calendar: calendar)
+
+        let store = TodayStore(
+            scheduledDoses: [dose],
+            prnMedications: [],
+            now: now,
+            calendar: calendar
+        )
+        store.markTaken(doseID: "dose-1", at: now)
+
+        XCTAssertEqual(store.doseLogs.count, 1)
+        XCTAssertEqual(store.doseLogs.first?.status, .taken)
+        XCTAssertEqual(store.doseItems.first?.state, .taken)
+    }
+
+    func testSnoozeThenSkipFlowPersistsExpectedState() {
+        let calendar = makeUTCCalendar()
+        let now = makeDate(hour: 10, minute: 0, calendar: calendar)
+        let dose = makeDose(id: "dose-1", hour: 10, minute: 5, name: "Gabapentin", calendar: calendar)
+
+        let store = TodayStore(
+            scheduledDoses: [dose],
+            prnMedications: [],
+            now: now,
+            calendar: calendar
+        )
+
+        store.snoozeDose(doseID: "dose-1", minutes: 20, at: now)
+        XCTAssertEqual(store.doseItems.first?.state, .snoozed)
+
+        store.advanceClock(to: makeDate(hour: 10, minute: 30, calendar: calendar))
+        XCTAssertEqual(store.doseItems.first?.state, .dueNow)
+
+        store.skipDose(doseID: "dose-1", reason: "Not at home", at: makeDate(hour: 10, minute: 31, calendar: calendar))
+        XCTAssertEqual(store.doseItems.first?.state, .skipped)
+        XCTAssertEqual(store.doseLogs.first?.note, "Not at home")
+    }
+
+    func testPRNQuickLogCreatesPRNEntry() {
+        let calendar = makeUTCCalendar()
+        let now = makeDate(hour: 11, minute: 0, calendar: calendar)
+        let prn = PRNMedication(
+            id: "prn-ibuprofen",
+            vaultId: "vault-1",
+            medicationName: "Ibuprofen",
+            dosage: "200 mg"
+        )
+
+        let store = TodayStore(
+            scheduledDoses: [],
+            prnMedications: [prn],
+            now: now,
+            calendar: calendar
+        )
+
+        store.logPRN(medicationID: "prn-ibuprofen", at: now)
+
+        XCTAssertEqual(store.prnHistoryToday.count, 1)
+        XCTAssertTrue(store.prnHistoryToday[0].isPRN)
+        XCTAssertEqual(store.prnHistoryToday[0].medicationName, "Ibuprofen")
+        XCTAssertEqual(store.prnHistoryToday[0].status, .taken)
+    }
+
+    private func makeDose(
+        id: String,
+        hour: Int,
+        minute: Int,
+        name: String,
+        calendar: Calendar
+    ) -> ScheduledDose {
+        ScheduledDose(
+            id: id,
+            vaultId: "vault-1",
+            medicationID: "med-\(id)",
+            medicationName: name,
+            dosage: "1 tablet",
+            scheduledAt: makeDate(hour: hour, minute: minute, calendar: calendar)
+        )
+    }
+
+    private func makeDate(hour: Int, minute: Int, calendar: Calendar) -> Date {
+        let base = DateComponents(calendar: calendar, year: 2026, month: 6, day: 1)
+        let day = calendar.date(from: base)!
+        return calendar.date(bySettingHour: hour, minute: minute, second: 0, of: day)!
+    }
+
+    private func makeUTCCalendar() -> Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(secondsFromGMT: 0)!
+        return calendar
+    }
+}


### PR DESCRIPTION
## Description

Implements the iOS Today view feature slice for dose confirmation in issue #47.

### What's included
- Added a new standalone Swift package at `ios/today-view/PildoraTodayView`.
- Introduced Today-domain models for time windows, dose states, scheduled doses, PRN medications, and dose logs.
- Added `TodayStore` with in-memory state derivation for chronological grouping and dose state resolution (upcoming, due now, overdue, taken, skipped, snoozed).
- Implemented dose actions for one-tap taken, skip, snooze (+15m), and PRN quick logging with log persistence in the store.
- Built `TodayView` UI with grouped timeline sections, due/overdue visual emphasis, swipe actions (Taken/Skip/Snooze), PRN quick-log section, and "all done" empty state.
- Added iOS haptic feedback for confirmation actions (UIKit-guarded).
- Added `TodayStoreTests` for grouping order, state classification, taken/snooze/skip transitions, and PRN quick logging behavior.
- Updated `ios/README.md` to include the new Today view feature slice.
- Updated `CHANGELOG.md` Unreleased (`### Added`) with a user-facing Today view entry.

## Related Issues

Closes #47

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Component

- [ ] `crypto/` — Encryption library
- [x] `ios/` — Apple platform apps
- [ ] `web/` — Web app
- [ ] `cli/` — CLI tool
- [ ] `server/` — Sync server
- [ ] `data/` — Drug data pipeline
- [x] `docs/` — Documentation

## Privacy Checklist

- [x] No plaintext user health data is sent to or stored on the server
- [x] No new metadata exposure introduced (or documented if unavoidable)
- [ ] Drug/health features include appropriate disclaimers and source attribution
- [x] Any new external service interaction is documented in the trust boundary model

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] Tests pass (if applicable)
- [x] I have updated documentation (if applicable)
