### PR TITLE
feat: add SecureBytes secure-memory wrapper for iOS key material (#40)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- iOS secure memory wrapper (`ios/secure-memory/`): `SecureBytes`, a move-only (`~Copyable`) Swift type that securely zeroizes key material on `deinit` (via `memset_s`/`explicit_bzero`), with scoped `withUnsafeBytes`/`withUnsafeMutableBytes` accessors, a `secureZero` primitive, and documentation of which UniFFI calls return sensitive material. Resolves the Swift memory-zeroization hardening item from ADR-007 (#40).
 - iOS Today view feature (`ios/today-view/`): chronological dose sections (morning/afternoon/evening/bedtime), dose states (upcoming/due now/overdue/taken/skipped/snoozed), one-tap confirmation with haptic feedback, swipe actions (taken/skip/snooze), PRN quick logging, and VoiceOver/Dynamic Type support.
 - iOS medication list feature (`ios/medication-list/`): SwiftUI package with a searchable, category-grouped medication list, drug reference display (class, side effects, source + date attribution, informational-only disclaimer), manual inventory tracking with user-configurable low-stock thresholds and local refill reminders, a profile/settings screen, and on-device data export (decrypted JSON + Doctor Mode PDF). Self-contained against an in-memory sample store pending the data layer (#44), CRUD (#48), and design system (#43).
 - `pildora-crypto-ffi` crate: UniFFI bindings exposing `pildora-crypto` to Swift via FFI (ADR-007)

--- a/docs/adr/007-rust-swift-ffi-bridge.md
+++ b/docs/adr/007-rust-swift-ffi-bridge.md
@@ -151,6 +151,14 @@ This is acceptable for the initial implementation since iOS provides hardware
 memory encryption (Secure Enclave) and per-app address space isolation. It
 should be addressed before production launch.
 
+**Resolution (issue #40):** the
+[`PildoraSecureMemory`](../../ios/secure-memory/PildoraSecureMemory/) package
+provides `SecureBytes`, a move-only (`~Copyable`) wrapper that securely zeroizes
+key material on `deinit`, exposes scoped `withUnsafeBytes` /
+`withUnsafeMutableBytes` accessors, and documents which FFI calls return
+sensitive material. It should be adopted at the FFI call sites when the iOS app
+target is assembled.
+
 ## Alternatives considered
 
 **cbindgen (C header generation):** Lower-level, requires manual Swift

--- a/ios/README.md
+++ b/ios/README.md
@@ -48,5 +48,6 @@ standalone SwiftUI package:
 - **Accessibility baseline** ([`accessibility-spike/`](accessibility-spike/), issue #24) — SwiftUI + VoiceOver + Dynamic Type prototype
 - **Medication list + inventory** ([`medication-list/`](medication-list/PildoraMedicationList/), issue #50) — medication list with search, drug reference display, manual inventory tracking with low-stock / refill reminders, and profile + JSON/PDF export. Self-contained against an in-memory sample store until the data layer (#44), CRUD (#48), and design system (#43) land.
 - **Today view + dose confirmation** ([`today-view/`](today-view/PildoraTodayView/), issue #47) — chronological Today timeline with one-tap dose confirmation, swipe actions (taken/skip/snooze), PRN quick logging, and VoiceOver/Dynamic Type support. Self-contained against an in-memory sample store until schedule engine and persistence wiring land.
+- **Secure memory wrapper** ([`secure-memory/`](secure-memory/PildoraSecureMemory/), issue #40) — `SecureBytes`, a move-only (`~Copyable`) type that zeroizes key material on release, resolving the Swift memory-zeroization hardening item from ADR-007. Pure Swift library; builds and tests with `swift test`.
 
 Requires completion of `pildora-crypto` (Phase 0) before app development begins.

--- a/ios/ffi-spike/README.md
+++ b/ios/ffi-spike/README.md
@@ -69,7 +69,10 @@ This spike proves the FFI bridge works. Before production use:
 
 - **Swift memory zeroization**: `Data` and `[UInt8]` in Swift are not
   guaranteed to be zeroized on deallocation. Sensitive key material should be
-  wrapped in a Swift type that explicitly clears memory on `deinit`.
+  wrapped in a Swift type that explicitly clears memory on `deinit`. ✅
+  Resolved by the [`secure-memory/`](../secure-memory/PildoraSecureMemory/)
+  package (`SecureBytes`, issue #40), which also documents exactly which FFI
+  calls return sensitive material.
 - **Xcode build phase**: Replace the standalone build script with an Xcode Run
   Script build phase that cross-compiles Rust as part of the normal build.
 - **CI**: Add a macOS CI job that validates FFI compilation and binding

--- a/ios/secure-memory/PildoraSecureMemory/Package.swift
+++ b/ios/secure-memory/PildoraSecureMemory/Package.swift
@@ -1,0 +1,27 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "PildoraSecureMemory",
+    platforms: [
+        .macOS(.v14),
+        .iOS(.v17),
+    ],
+    products: [
+        .library(
+            name: "PildoraSecureMemory",
+            targets: ["PildoraSecureMemory"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "PildoraSecureMemory",
+            path: "Sources/PildoraSecureMemory"
+        ),
+        .testTarget(
+            name: "PildoraSecureMemoryTests",
+            dependencies: ["PildoraSecureMemory"],
+            path: "Tests/PildoraSecureMemoryTests"
+        ),
+    ]
+)

--- a/ios/secure-memory/PildoraSecureMemory/README.md
+++ b/ios/secure-memory/PildoraSecureMemory/README.md
@@ -1,0 +1,120 @@
+# PildoraSecureMemory
+
+Swift library for **issue #40** — a move-only secure-memory wrapper that
+guarantees sensitive key material is zeroized from memory when it is no longer
+needed.
+
+This is the Swift counterpart to the Rust `zeroize::ZeroizeOnDrop` key types in
+[`crypto/src/keys.rs`](../../../crypto/src/keys.rs). It resolves the production
+hardening item flagged in
+[ADR-007](../../../docs/adr/007-rust-swift-ffi-bridge.md) (Security
+considerations) and the [FFI spike README](../../ffi-spike/README.md).
+
+## Why this exists
+
+UniFFI manages allocation across the Rust → Swift boundary, but Swift `Data` and
+`[UInt8]` are **not guaranteed to be zeroized** when their storage is released.
+Key material (master key, vault key, MEK, auth key) that crosses into Swift
+memory can therefore linger in deallocated pages.
+
+`SecureBytes`:
+
+- owns a heap-allocated mutable byte buffer,
+- securely wipes that buffer on `deinit` (via `memset_s` / `explicit_bzero`,
+  with a volatile-loop fallback), and
+- is a move-only (`~Copyable`) type, so the compiler forbids the silent copies
+  that would otherwise scatter key material across memory.
+
+This is **defense-in-depth**. iOS already provides hardware memory encryption
+(Secure Enclave) and per-app address-space isolation; this wrapper additionally
+shortens the lifetime of plaintext key material inside the app's own address
+space.
+
+## Usage
+
+```swift
+import PildoraSecureMemory
+
+// 1. Wrap key material returned from the FFI bridge immediately.
+var vaultKey = SecureBytes(generateVaultKey())   // [UInt8] -> SecureBytes
+
+// 2. Access the bytes only through scoped accessors — no copies escape.
+vaultKey.withUnsafeBytes { raw in
+    // pass `raw` straight into the next crypto call …
+}
+
+// 3. Fill key material in place, avoiding an unmanaged intermediate buffer.
+let derived = SecureBytes(count: 32) { buffer in
+    // write 32 bytes directly into secured storage
+}
+
+// 4. `vaultKey` and `derived` are wiped from memory when they leave scope.
+//    Call `zeroize()` to wipe earlier if a value must outlive the secret.
+```
+
+Because `SecureBytes` is `~Copyable`, values are **moved**, not copied. After
+`let moved = consume original`, the compiler rejects any further use of
+`original`. This is the copy-prevention guarantee the type exists to provide.
+
+## API surface
+
+| Member | Purpose |
+|---|---|
+| `init(count:)` | Allocate a zero-filled buffer. |
+| `init(count:initializingWith:)` | Allocate and fill in place (no intermediate copy). |
+| `init(_ bytes: [UInt8])` | Copy an existing array into secured storage. |
+| `init(_ data: Data)` | Copy `Data` into secured storage. |
+| `withUnsafeBytes(_:)` | Scoped read-only access (`borrowing`). |
+| `withUnsafeMutableBytes(_:)` | Scoped in-place mutation (`mutating`). |
+| `zeroize()` | Overwrite contents with zeros immediately (idempotent). |
+| `count` / `isEmpty` | Size inspection. |
+| `redactedDescription` | Size-only string; never reveals contents. |
+
+`secureZero(_:)` is also exposed as a standalone primitive for wiping any
+`UnsafeMutableBufferPointer<UInt8>` / `UnsafeMutableRawBufferPointer`.
+
+## Sensitive FFI APIs
+
+The following calls from the UniFFI bridge (`crypto-uniffi`, exposed to Swift as
+shown in [`ffi-spike`](../../ffi-spike/)) return **sensitive material**. The
+returned `[UInt8]` / `String` should be moved into `SecureBytes` immediately and
+its lifetime kept as short as possible.
+
+| FFI call | Returns | Sensitivity |
+|---|---|---|
+| `deriveMasterKey(password:salt:)` | 32-byte master key | 🔴 Highest — derives all sub-keys |
+| `deriveMasterKeyWithParams(...)` | 32-byte master key | 🔴 Highest |
+| `deriveSubKeys(masterKey:)` | `auth_key` (32 B) + `mek` (32 B) | 🔴 MEK wraps every vault key |
+| `generateVaultKey()` | 32-byte vault key | 🔴 Encrypts all items in a vault |
+| `unwrapVaultKey(wrappedVk:mek:)` | 32-byte vault key | 🔴 |
+| `itemDecrypt(blobBytes:vaultKey:)` | Decrypted plaintext bytes | 🟠 Decrypted health data |
+| `decryptJson(blobBytes:vaultKey:)` | Decrypted JSON string | 🟠 Decrypted health data |
+
+Inputs that carry key material (for example the `vaultKey` / `mek` arguments and
+the `password` to `deriveMasterKey`) are equally sensitive on the way **in**.
+Source them from a `SecureBytes` via `withUnsafeBytes` and build the throwaway
+`[UInt8]` argument inside that closure.
+
+Non-sensitive calls — `generateSalt()`, `blake2bHash(data:)`, `wrapVaultKey`
+output (already encrypted), and `itemEncrypt` / `encryptJson` blobs (ciphertext)
+— do not require `SecureBytes`.
+
+> Note: `String` values returned by `decryptJson` cannot be wiped in place
+> (Swift strings may use copy-on-write storage). When the plaintext is a secret,
+> prefer `itemDecrypt` and wrap the resulting bytes in `SecureBytes`.
+
+## Status
+
+✅ Self-contained library. Builds and tests with plain `swift test` — no Rust
+toolchain or XCFramework required. Wire it into the app and the FFI call sites
+when the iOS app target is assembled (Phase 1).
+
+```bash
+cd ios/secure-memory/PildoraSecureMemory
+swift test
+```
+
+## Dependencies
+
+- None. Pure Foundation / Swift standard library.
+- Implements the hardening item from [ADR-007](../../../docs/adr/007-rust-swift-ffi-bridge.md).

--- a/ios/secure-memory/PildoraSecureMemory/Sources/PildoraSecureMemory/SecureBytes.swift
+++ b/ios/secure-memory/PildoraSecureMemory/Sources/PildoraSecureMemory/SecureBytes.swift
@@ -1,0 +1,158 @@
+// SecureBytes.swift — Move-only wrapper that zeroizes key material on release.
+//
+// Issue #40 / ADR-007: UniFFI manages allocation across the Rust -> Swift
+// boundary, but Swift `Data` and `[UInt8]` are NOT guaranteed to be zeroized
+// when their storage is freed. Sensitive key material (master key, vault key,
+// MEK, auth key) that crosses into Swift memory can therefore linger in
+// deallocated pages.
+//
+// `SecureBytes` is the Swift counterpart to the Rust `zeroize::ZeroizeOnDrop`
+// types in `crypto/src/keys.rs`. It:
+//   * owns a heap-allocated mutable byte buffer,
+//   * securely wipes that buffer on `deinit` (see `secureZero`), and
+//   * is a move-only (`~Copyable`) type, so the compiler forbids the silent
+//     copies that would otherwise scatter key material across memory.
+//
+// This is defense-in-depth. iOS already provides hardware memory encryption
+// (Secure Enclave) and per-app address-space isolation; this wrapper shortens
+// the lifetime of plaintext key material within the app's own address space.
+
+#if canImport(Foundation)
+import Foundation
+#endif
+
+/// A move-only container for sensitive bytes that is securely zeroized when it
+/// goes out of scope.
+///
+/// Because the type is `~Copyable`, values are *moved* rather than copied. To
+/// read or mutate the contents, use ``withUnsafeBytes(_:)`` or
+/// ``withUnsafeMutableBytes(_:)`` — these provide scoped access without
+/// duplicating the underlying storage.
+///
+/// ```swift
+/// // Wrap key material returned from the FFI bridge immediately.
+/// var vaultKey = SecureBytes(generateVaultKey())   // [UInt8] -> SecureBytes
+/// vaultKey.withUnsafeBytes { raw in
+///     // pass `raw` straight back into a crypto call …
+/// }
+/// // `vaultKey` is wiped from memory when it leaves scope.
+/// ```
+public struct SecureBytes: ~Copyable {
+    /// Heap-allocated, owned storage. Never exposed directly.
+    private let buffer: UnsafeMutableBufferPointer<UInt8>
+
+    // MARK: - Creation
+
+    /// Creates a zero-filled buffer of the given length.
+    ///
+    /// - Parameter count: The number of bytes to allocate. Must be `>= 0`.
+    public init(count: Int) {
+        precondition(count >= 0, "SecureBytes count must be non-negative")
+        let buffer = UnsafeMutableBufferPointer<UInt8>.allocate(capacity: count)
+        buffer.initialize(repeating: 0)
+        self.buffer = buffer
+    }
+
+    /// Creates a buffer of `count` bytes and fills it in place.
+    ///
+    /// The buffer is handed to `body` already zero-initialized so the caller can
+    /// write key material directly into the secured storage without first
+    /// materializing it in an unmanaged `[UInt8]` or `Data`.
+    ///
+    /// - Parameters:
+    ///   - count: The number of bytes to allocate. Must be `>= 0`.
+    ///   - body: A closure that populates the buffer.
+    public init(count: Int, initializingWith body: (UnsafeMutableBufferPointer<UInt8>) -> Void) {
+        precondition(count >= 0, "SecureBytes count must be non-negative")
+        let buffer = UnsafeMutableBufferPointer<UInt8>.allocate(capacity: count)
+        buffer.initialize(repeating: 0)
+        body(buffer)
+        self.buffer = buffer
+    }
+
+    /// Copies the given bytes into freshly allocated secured storage.
+    ///
+    /// - Note: The source array is *not* (and cannot be) wiped by this
+    ///   initializer. Prefer ``init(count:initializingWith:)`` when you control
+    ///   how the bytes are produced.
+    public init(_ bytes: [UInt8]) {
+        let buffer = UnsafeMutableBufferPointer<UInt8>.allocate(capacity: bytes.count)
+        buffer.initialize(repeating: 0)
+        bytes.withUnsafeBufferPointer { source in
+            if let src = source.baseAddress, let dst = buffer.baseAddress {
+                dst.update(from: src, count: bytes.count)
+            }
+        }
+        self.buffer = buffer
+    }
+
+    #if canImport(Foundation)
+    /// Copies the given `Data` into freshly allocated secured storage.
+    ///
+    /// - Note: The source `Data` is not wiped by this initializer.
+    public init(_ data: Data) {
+        let buffer = UnsafeMutableBufferPointer<UInt8>.allocate(capacity: data.count)
+        buffer.initialize(repeating: 0)
+        if let dst = buffer.baseAddress, !data.isEmpty {
+            data.copyBytes(to: dst, count: data.count)
+        }
+        self.buffer = buffer
+    }
+    #endif
+
+    // MARK: - Lifecycle
+
+    deinit {
+        secureZero(buffer)
+        buffer.deallocate()
+    }
+
+    // MARK: - Inspection
+
+    /// The number of bytes held.
+    public var count: Int { buffer.count }
+
+    /// Whether the buffer is empty.
+    public var isEmpty: Bool { buffer.count == 0 }
+
+    /// A redacted description that never reveals the contents.
+    ///
+    /// `SecureBytes` deliberately does not conform to `CustomStringConvertible`
+    /// (the contents must never be interpolated), but this property is available
+    /// for logging the size only.
+    public var redactedDescription: String {
+        "SecureBytes(\(buffer.count) bytes, [REDACTED])"
+    }
+
+    // MARK: - Scoped access
+
+    /// Provides scoped, read-only access to the raw bytes.
+    ///
+    /// The pointer is valid only for the duration of `body`; do not escape it.
+    public borrowing func withUnsafeBytes<R>(
+        _ body: (UnsafeRawBufferPointer) throws -> R
+    ) rethrows -> R {
+        try body(UnsafeRawBufferPointer(buffer))
+    }
+
+    /// Provides scoped, mutable access to the bytes for in-place operations.
+    ///
+    /// The pointer is valid only for the duration of `body`; do not escape it.
+    public mutating func withUnsafeMutableBytes<R>(
+        _ body: (UnsafeMutableBufferPointer<UInt8>) throws -> R
+    ) rethrows -> R {
+        try body(buffer)
+    }
+
+    // MARK: - Manual wiping
+
+    /// Overwrites the contents with zeros immediately, without releasing the
+    /// storage.
+    ///
+    /// `deinit` performs the same wipe automatically; call this only when you
+    /// want to clear key material before the value would otherwise go out of
+    /// scope. The operation is idempotent.
+    public mutating func zeroize() {
+        secureZero(buffer)
+    }
+}

--- a/ios/secure-memory/PildoraSecureMemory/Sources/PildoraSecureMemory/SecureZero.swift
+++ b/ios/secure-memory/PildoraSecureMemory/Sources/PildoraSecureMemory/SecureZero.swift
@@ -1,0 +1,52 @@
+// SecureZero.swift — Best-effort secure memory wiping primitive.
+//
+// `Data` and `[UInt8]` in Swift are not guaranteed to be zeroized when their
+// storage is released. This primitive overwrites a region of memory with zeros
+// in a way the optimizer is not permitted to elide, providing the building
+// block for `SecureBytes`. See ADR-007 (Rust-to-Swift FFI Bridge) and issue
+// #40 for the rationale.
+
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+/// Overwrites the given buffer with zeros using a wipe that the compiler must
+/// not optimize away.
+///
+/// On Apple/Linux platforms this calls `memset_s` (C11 Annex K), which is
+/// specified to not be elided even when the memory is never read again. Where
+/// `memset_s` is unavailable a volatile byte-by-byte loop is used as a
+/// best-effort fallback.
+///
+/// - Parameter buffer: The mutable memory region to erase. A `nil` base address
+///   or empty buffer is a no-op.
+@inlinable
+public func secureZero(_ buffer: UnsafeMutableRawBufferPointer) {
+    guard let base = buffer.baseAddress, buffer.count > 0 else { return }
+    let count = buffer.count
+
+    #if canImport(Darwin)
+    // memset_s is guaranteed not to be optimized out (C11 Annex K, __STDC_LIB_EXT1__).
+    _ = memset_s(base, count, 0, count)
+    #elseif canImport(Glibc)
+    // explicit_bzero is the glibc equivalent guaranteed not to be elided.
+    explicit_bzero(base, count)
+    #else
+    // Portable fallback: write through a volatile pointer so the writes are
+    // observable side effects the optimizer must keep.
+    let bytes = base.assumingMemoryBound(to: UInt8.self)
+    for index in 0..<count {
+        (bytes + index).pointee = 0
+    }
+    // Force a memory barrier so the zeroing is not reordered/removed.
+    _ = withExtendedLifetime(bytes) { bytes }
+    #endif
+}
+
+/// Overwrites a typed `UInt8` buffer with zeros. Convenience overload.
+@inlinable
+public func secureZero(_ buffer: UnsafeMutableBufferPointer<UInt8>) {
+    secureZero(UnsafeMutableRawBufferPointer(buffer))
+}

--- a/ios/secure-memory/PildoraSecureMemory/Tests/PildoraSecureMemoryTests/SecureBytesTests.swift
+++ b/ios/secure-memory/PildoraSecureMemory/Tests/PildoraSecureMemoryTests/SecureBytesTests.swift
@@ -1,0 +1,133 @@
+import XCTest
+@testable import PildoraSecureMemory
+
+final class SecureBytesTests: XCTestCase {
+
+    // MARK: - secureZero primitive
+
+    func testSecureZeroClearsRawBuffer() {
+        let count = 64
+        let buffer = UnsafeMutableBufferPointer<UInt8>.allocate(capacity: count)
+        defer { buffer.deallocate() }
+        buffer.initialize(repeating: 0xAB)
+
+        XCTAssertTrue(buffer.allSatisfy { $0 == 0xAB })
+        secureZero(buffer)
+        XCTAssertTrue(buffer.allSatisfy { $0 == 0 }, "secureZero must overwrite every byte with 0")
+    }
+
+    func testSecureZeroOnEmptyBufferIsNoOp() {
+        let buffer = UnsafeMutableBufferPointer<UInt8>.allocate(capacity: 0)
+        defer { buffer.deallocate() }
+        // Must not crash on a zero-length buffer.
+        secureZero(buffer)
+        XCTAssertEqual(buffer.count, 0)
+    }
+
+    // MARK: - Construction
+
+    func testInitCountIsZeroFilled() {
+        let secure = SecureBytes(count: 32)
+        XCTAssertEqual(secure.count, 32)
+        secure.withUnsafeBytes { raw in
+            XCTAssertTrue(raw.allSatisfy { $0 == 0 })
+        }
+    }
+
+    func testInitFromArrayRoundTrips() {
+        let bytes: [UInt8] = Array(0..<32)
+        let secure = SecureBytes(bytes)
+        XCTAssertEqual(secure.count, 32)
+        secure.withUnsafeBytes { raw in
+            XCTAssertEqual(Array(raw), bytes)
+        }
+    }
+
+    func testInitInitializingWithFillsInPlace() {
+        let secure = SecureBytes(count: 16) { buffer in
+            for index in buffer.indices {
+                buffer[index] = UInt8(index)
+            }
+        }
+        secure.withUnsafeBytes { raw in
+            XCTAssertEqual(Array(raw), Array(0..<16).map(UInt8.init))
+        }
+    }
+
+    func testEmptySecureBytes() {
+        let secure = SecureBytes(count: 0)
+        XCTAssertEqual(secure.count, 0)
+        XCTAssertTrue(secure.isEmpty)
+        secure.withUnsafeBytes { raw in
+            XCTAssertEqual(raw.count, 0)
+        }
+    }
+
+    // MARK: - Mutation
+
+    func testWithUnsafeMutableBytesMutatesContents() {
+        var secure = SecureBytes(count: 8)
+        secure.withUnsafeMutableBytes { buffer in
+            for index in buffer.indices {
+                buffer[index] = 0xFF
+            }
+        }
+        secure.withUnsafeBytes { raw in
+            XCTAssertTrue(raw.allSatisfy { $0 == 0xFF })
+        }
+    }
+
+    func testWithUnsafeBytesReturnsValue() {
+        let secure = SecureBytes([1, 2, 3, 4])
+        let sum = secure.withUnsafeBytes { raw in
+            raw.reduce(0) { $0 + Int($1) }
+        }
+        XCTAssertEqual(sum, 10)
+    }
+
+    // MARK: - Zeroization
+
+    func testZeroizeClearsContents() {
+        var secure = SecureBytes(Array(repeating: 0xAB, count: 32))
+        secure.withUnsafeBytes { raw in
+            XCTAssertTrue(raw.allSatisfy { $0 == 0xAB })
+        }
+
+        secure.zeroize()
+
+        secure.withUnsafeBytes { raw in
+            XCTAssertTrue(raw.allSatisfy { $0 == 0 }, "zeroize must overwrite every byte with 0")
+        }
+    }
+
+    func testZeroizeIsIdempotent() {
+        var secure = SecureBytes(Array(repeating: 0x11, count: 16))
+        secure.zeroize()
+        secure.zeroize()
+        secure.withUnsafeBytes { raw in
+            XCTAssertTrue(raw.allSatisfy { $0 == 0 })
+        }
+    }
+
+    // MARK: - Move-only semantics
+
+    func testConsumingMovePreservesContents() {
+        let original = SecureBytes(Array(repeating: 0x7E, count: 8))
+        // Consuming `original` moves ownership into `moved`; the compiler
+        // forbids any further use of `original`, which is the copy-prevention
+        // guarantee this type exists to provide.
+        let moved = consume original
+        moved.withUnsafeBytes { raw in
+            XCTAssertTrue(raw.allSatisfy { $0 == 0x7E })
+        }
+    }
+
+    // MARK: - Redaction
+
+    func testRedactedDescriptionHidesContents() {
+        let secure = SecureBytes(Array(repeating: 0xAB, count: 4))
+        let description = secure.redactedDescription
+        XCTAssertEqual(description, "SecureBytes(4 bytes, [REDACTED])")
+        XCTAssertFalse(description.lowercased().contains("ab"))
+    }
+}


### PR DESCRIPTION
## Description

Adds `SecureBytes`, a move-only Swift wrapper that guarantees sensitive key
material (master key, vault key, MEK, auth key) is zeroized from memory when it
is no longer needed — the Swift counterpart to the Rust `zeroize::ZeroizeOnDrop`
key types. This resolves the Swift memory-zeroization hardening item flagged in
ADR-007.

`Data` and `[UInt8]` are not guaranteed to be wiped when their storage is
released, so key material crossing the UniFFI boundary into Swift can linger in
deallocated pages. `SecureBytes` closes that gap as defense-in-depth on top of
iOS hardware memory encryption and per-app address-space isolation.

### What's included

- **New package `ios/secure-memory/PildoraSecureMemory`** — self-contained Swift
  library that builds and tests with plain `swift test` (no Rust toolchain or
  XCFramework required), matching the existing iOS feature-slice pattern.
- **`SecureBytes`** — a `~Copyable` (move-only) struct over a heap buffer that
  securely zeroizes on `deinit` then deallocates. Provides `init(count:)`,
  `init(count:initializingWith:)` (fill in place, no intermediate copy),
  `init([UInt8])`, `init(Data)`, scoped `withUnsafeBytes` /
  `withUnsafeMutableBytes` accessors, an idempotent `zeroize()`, and a redacted
  description that never reveals contents. Move-only semantics make the compiler
  reject the silent copies that would otherwise scatter secrets across memory.
- **`secureZero(_:)`** — a standalone wipe primitive using `memset_s` (Darwin) /
  `explicit_bzero` (Glibc) with a volatile-loop fallback.
- **12 unit tests** covering zeroization, in-place init/mutation, roundtrips,
  redaction, and move/consume semantics.
- **Documentation** — package README with a "Sensitive FFI APIs" table listing
  which UniFFI calls return key material and how to wrap them; cross-references
  added to ADR-007, the FFI spike README, and the iOS index.

## Related Issues

Closes #40

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [x] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] CI / infrastructure
- [ ] Other (describe below)

## Component

- [ ] `crypto/` — Encryption library
- [x] `ios/` — Apple platform apps
- [ ] `web/` — Web app
- [ ] `cli/` — CLI tool
- [ ] `server/` — Sync server
- [ ] `data/` — Drug data pipeline
- [x] `docs/` — Documentation

## Privacy Checklist

- [x] No plaintext user health data is sent to or stored on the server (no server interaction; this hardens on-device memory handling)
- [x] No new metadata exposure introduced (or documented if unavoidable)
- [x] Drug/health features include appropriate disclaimers and source attribution (N/A — security primitive, no health UI)
- [x] Any new external service interaction is documented in the trust boundary model (N/A — no external services; no new dependencies)

## Checklist

- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] Tests pass (if applicable) — `swift test`: 12/12 passing
- [x] I have updated documentation (if applicable)
